### PR TITLE
[mod] 바텀 네비게이션 / MaterialComponents 사용하도록 변경 

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,35 +16,24 @@
             android:id="@+id/fcv_main"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@id/line1_main"
+            app:layout_constraintBottom_toTopOf="@+id/bnv_main"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:layout="@layout/fragment_feed" />
 
-        <View
-            android:id="@+id/line1_main"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:backgroundTint="@color/gray_200"
-            app:layout_constraintBottom_toTopOf="@id/bnv_main"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/bnv_main"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="56dp"
             app:itemIconTint="@drawable/sel_main_bnv_icon_color"
             app:itemTextAppearanceActive="@style/TextAppearance.WINEY.detail_m_12"
             app:itemTextAppearanceInactive="@style/TextAppearance.WINEY.detail_m_12"
             app:itemTextColor="@drawable/sel_main_bnv_icon_color"
-            app:itemBackground="?colorSurface"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:menu="@menu/menu_main" />
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,8 +1,6 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="Theme.Winey" parent="Theme.Material3.Light.NoActionBar">
-        <!-- default background color. -->
-        <item name="android:windowBackground">@color/gray_0</item>
+    <style name="Theme.Winey" parent="Theme.MaterialComponents.Light.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_400</item>
         <item name="colorPrimaryVariant">@color/gray_0</item>
@@ -14,14 +12,10 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
-        <!-- Customize your theme here. -->
-
-        <!-- Navigation Bar Container color -->
+        <!-- Neutral key color -->
         <item name="colorSurface">@color/gray_0</item>
-
         <!-- Navigation Bar Icon/Text Active color -->
         <item name="colorOnSurface">@color/purple_400</item>
-
         <!-- Navigation Bar Icon/Text Inactive color -->
         <item name="colorOnSurfaceVariant">@color/gray_300</item>
     </style>


### PR DESCRIPTION
- closed #10

## 📝 Work Description

Material3 대신 MaterialComponents 사용하도록 변경 

## 📸 Screenshot

<img width="350dp" src="https://github.com/team-winey/Winey-AOS/assets/68090939/22923245-2410-479f-8254-06b742ffaeb6" />

## 📣 To Reviewers

수정된 코드 확인하고 리뷰 부탁드려요!