### PR TITLE
[fix] 위니 업로드 / 자잘한 버그 수정 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,8 +37,8 @@
 
         <activity
             android:name=".presentation.main.feed.upload.loading.LoadingActivity"
-            android:screenOrientation="portrait"
-            android:exported="false" />
+            android:exported="false"
+            android:screenOrientation="portrait" />
 
         <activity
             android:name=".presentation.main.mypage.MypageHelpActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,22 +17,6 @@
         tools:targetApi="31">
 
         <activity
-            android:name=".presentation.main.feed.upload.loading.LoadingActivity"
-            android:exported="false" />
-
-        <activity
-            android:name=".presentation.main.mypage.MypageHelpActivity"
-            android:exported="false"
-            android:screenOrientation="portrait" />
-
-        <activity
-            android:name=".presentation.main.feed.upload.UploadActivity"
-            android:exported="true"
-            android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustResize">
-        </activity>
-
-        <activity
             android:name=".presentation.main.MainActivity"
             android:exported="true"
             android:screenOrientation="portrait">
@@ -44,6 +28,22 @@
             </intent-filter>
 
         </activity>
+
+        <activity
+            android:name=".presentation.main.feed.upload.UploadActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize" />
+
+        <activity
+            android:name=".presentation.main.feed.upload.loading.LoadingActivity"
+            android:screenOrientation="portrait"
+            android:exported="false" />
+
+        <activity
+            android:name=".presentation.main.mypage.MypageHelpActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
 
     </application>
 

--- a/app/src/main/java/com/android/go/sopt/winey/data/model/remote/response/ResponseGetRecommendListDto.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/data/model/remote/response/ResponseGetRecommendListDto.kt
@@ -10,34 +10,35 @@ data class ResponseGetRecommendListDto(
     val pageResponseDto: PageResponseDto,
     @SerialName("recommendsResponseDto")
     val recommendsResponseDto: List<RecommendsResponseDto>
-){
+) {
     @Serializable
     data class PageResponseDto(
         @SerialName("totalPageSize")
-        val totalPageSize : Int,
+        val totalPageSize: Int,
         @SerialName("currentPageIndex")
-        val currentPageIndex : Int,
+        val currentPageIndex: Int,
         @SerialName("isEnd")
-        val isEnd : Boolean,
+        val isEnd: Boolean,
     )
 
     @Serializable
     data class RecommendsResponseDto(
         @SerialName("recommendId")
-        val recommendId : Int?,
+        val recommendId: Int?,
         @SerialName("recommendLink")
-        val recommendLink : String?,
+        val recommendLink: String?,
         @SerialName("recommendTitle")
-        val recommendTitle : String?,
+        val recommendTitle: String?,
         @SerialName("recommendSubTitle")
-        val recommendSubTitle : String?,
+        val recommendSubTitle: String?,
         @SerialName("recommendDiscount")
-        val recommendDiscount : String?,
+        val recommendDiscount: String?,
         @SerialName("recommendImage")
-        val recommendImage : String?,
+        val recommendImage: String?,
         @SerialName("createdAt")
-        val createdAt : String?
+        val createdAt: String?
     )
+
     fun convertToRecommend() = this.recommendsResponseDto.map {
         Recommend(
             id = it.recommendId ?: 0,

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/MainActivity.kt
@@ -12,7 +12,6 @@ import com.android.go.sopt.winey.presentation.main.mypage.MyPageFragment
 import com.android.go.sopt.winey.presentation.main.recommend.RecommendFragment
 import com.android.go.sopt.winey.util.binding.BindingActivity
 import dagger.hilt.android.AndroidEntryPoint
-import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
@@ -20,15 +19,13 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Timber.tag("생명주기").d("onCreate()....")
 
+        navigateTo<WineyFeedFragment>()
         initBnvItemSelectedListener()
         viewModel.getUser()
     }
 
     private fun initBnvItemSelectedListener() {
-        navigateTo<WineyFeedFragment>()
-
         binding.bnvMain.setOnItemSelectedListener { item ->
             when (item.itemId) {
                 R.id.menu_feed -> navigateTo<WineyFeedFragment>()

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/MainActivity.kt
@@ -22,7 +22,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
         navigateTo<WineyFeedFragment>()
         initBnvItemSelectedListener()
-        viewModel.getUser()
     }
 
     private fun initBnvItemSelectedListener() {

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/amount/AmountFragment.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/amount/AmountFragment.kt
@@ -10,8 +10,7 @@ import androidx.fragment.app.viewModels
 import com.android.go.sopt.winey.R
 import com.android.go.sopt.winey.databinding.FragmentAmountBinding
 import com.android.go.sopt.winey.presentation.main.feed.upload.loading.LoadingActivity
-import com.android.go.sopt.winey.util.BitmapRequestBody
-import com.android.go.sopt.winey.util.ImageCompressor
+import com.android.go.sopt.winey.util.UriToRequestBody
 import com.android.go.sopt.winey.util.binding.BindingFragment
 import com.android.go.sopt.winey.util.context.hideKeyboard
 import com.android.go.sopt.winey.util.fragment.snackBar
@@ -40,11 +39,13 @@ class AmountFragment : BindingFragment<FragmentAmountBinding>(R.layout.fragment_
     }
 
     private fun updateRequestBody() {
-        val compressor = ImageCompressor(requireContext(), imageUriArg!!)
-        val adjustedImageBitmap = compressor.adjustImageFormat()
-        val bitmapRequestBody =
-            BitmapRequestBody(requireContext(), imageUriArg, adjustedImageBitmap)
-        viewModel.updateRequestBody(bitmapRequestBody)
+//        val compressor = ImageCompressor(requireContext(), imageUriArg!!)
+//        val adjustedImageBitmap = compressor.adjustImageFormat()
+//        val bitmapRequestBody =
+//            BitmapRequestBody(requireContext(), imageUriArg, adjustedImageBitmap)
+
+        val requestBody = UriToRequestBody(requireContext(), imageUriArg!!)
+        viewModel.updateRequestBody(requestBody)
     }
 
     private fun initUploadButtonClickListener() {

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/amount/AmountViewModel.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/amount/AmountViewModel.kt
@@ -24,7 +24,7 @@ class AmountViewModel @Inject constructor(
     val _amount = MutableLiveData<String>()
     val amount: String get() = _amount.value ?: ""
 
-    val isValidAmount: LiveData<Boolean> = _amount.map { validateLength(it) }
+    val isValidAmount: LiveData<Boolean> = _amount.map { validateAmount(it.removeComma()) }
 
     private val _imageRequestBody = MutableLiveData<UriToRequestBody>()
     val imageRequestBody: LiveData<UriToRequestBody>
@@ -34,8 +34,9 @@ class AmountViewModel @Inject constructor(
     val postWineyFeedState: LiveData<UiState<ResponsePostWineyFeedDto?>>
         get() = _postWineyFeedState
 
-    private fun validateLength(amount: String): Boolean =
-        amount.length in MIN_AMOUNT_LENGTH..MAX_AMOUNT_LENGTH
+    private fun String.removeComma(): Long = replace(",", "").toLong()
+
+    private fun validateAmount(amount: Long): Boolean = amount in MIN_AMOUNT..MAX_AMOUNT
 
     fun updateRequestBody(requestBody: UriToRequestBody) {
         _imageRequestBody.value = requestBody
@@ -74,8 +75,8 @@ class AmountViewModel @Inject constructor(
     }
 
     companion object {
-        const val MIN_AMOUNT_LENGTH = 1
-        const val MAX_AMOUNT_LENGTH = 13
+        const val MIN_AMOUNT = 1
+        const val MAX_AMOUNT = 9999999
         private const val FEED_TITLE_KEY = "feedTitle"
         private const val FEED_MONEY_KEY = "feedMoney"
     }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/amount/AmountViewModel.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/amount/AmountViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.android.go.sopt.winey.data.model.remote.response.ResponsePostWineyFeedDto
 import com.android.go.sopt.winey.domain.repository.AuthRepository
-import com.android.go.sopt.winey.util.BitmapRequestBody
+import com.android.go.sopt.winey.util.UriToRequestBody
 import com.android.go.sopt.winey.util.view.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -26,8 +26,8 @@ class AmountViewModel @Inject constructor(
 
     val isValidAmount: LiveData<Boolean> = _amount.map { validateLength(it) }
 
-    private val _imageRequestBody = MutableLiveData<BitmapRequestBody>()
-    val imageRequestBody: LiveData<BitmapRequestBody>
+    private val _imageRequestBody = MutableLiveData<UriToRequestBody>()
+    val imageRequestBody: LiveData<UriToRequestBody>
         get() = _imageRequestBody
 
     private val _postWineyFeedState = MutableLiveData<UiState<ResponsePostWineyFeedDto?>>()
@@ -37,7 +37,7 @@ class AmountViewModel @Inject constructor(
     private fun validateLength(amount: String): Boolean =
         amount.length in MIN_AMOUNT_LENGTH..MAX_AMOUNT_LENGTH
 
-    fun updateRequestBody(requestBody: BitmapRequestBody) {
+    fun updateRequestBody(requestBody: UriToRequestBody) {
         _imageRequestBody.value = requestBody
     }
 

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/amount/AmountViewModel.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/amount/AmountViewModel.kt
@@ -24,7 +24,7 @@ class AmountViewModel @Inject constructor(
     val _amount = MutableLiveData<String>()
     val amount: String get() = _amount.value ?: ""
 
-    val isValidAmount: LiveData<Boolean> = _amount.map { validateAmount(it.removeComma()) }
+    val isValidAmount: LiveData<Boolean> = _amount.map { validateAmount(it) }
 
     private val _imageRequestBody = MutableLiveData<UriToRequestBody>()
     val imageRequestBody: LiveData<UriToRequestBody>
@@ -34,9 +34,15 @@ class AmountViewModel @Inject constructor(
     val postWineyFeedState: LiveData<UiState<ResponsePostWineyFeedDto?>>
         get() = _postWineyFeedState
 
-    private fun String.removeComma(): Long = replace(",", "").toLong()
+    private fun validateAmount(amount: String): Boolean {
+        if(amount.isBlank()) return false
+        if(!amount.contains(",")) return true // 최대 999
 
-    private fun validateAmount(amount: Long): Boolean = amount in MIN_AMOUNT..MAX_AMOUNT
+        val amountNumber = amount.removeComma().toLong()
+        return amountNumber in MIN_AMOUNT..MAX_AMOUNT
+    }
+
+    private fun String.removeComma() = replace(",", "")
 
     fun updateRequestBody(requestBody: UriToRequestBody) {
         _imageRequestBody.value = requestBody
@@ -75,7 +81,7 @@ class AmountViewModel @Inject constructor(
     }
 
     companion object {
-        const val MIN_AMOUNT = 1
+        const val MIN_AMOUNT = 1000
         const val MAX_AMOUNT = 9999999
         private const val FEED_TITLE_KEY = "feedTitle"
         private const val FEED_MONEY_KEY = "feedMoney"

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/content/ContentFragment.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/content/ContentFragment.kt
@@ -33,6 +33,9 @@ class ContentFragment : BindingFragment<FragmentContentBinding>(R.layout.fragmen
     private fun initBackButtonClickListener() {
         binding.ivContentBack.setOnClickListener {
             parentFragmentManager.popBackStack()
+
+            // todo: 이전 버튼 눌러서 포토 프래그먼트로 돌아가는 순간에
+            //  생명주기 함수에서 이미지 뷰의 스케일 타입을 조정하는 건 어떨까.
         }
     }
 

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/content/ContentViewModel.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/content/ContentViewModel.kt
@@ -15,7 +15,7 @@ class ContentViewModel : ViewModel() {
         content.length in MIN_CONTENT_LENGTH..MAX_CONTENT_LENGTH
 
     companion object {
-        const val MIN_CONTENT_LENGTH = 1
+        const val MIN_CONTENT_LENGTH = 6
         const val MAX_CONTENT_LENGTH = 36
     }
 }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/loading/LoadingActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/loading/LoadingActivity.kt
@@ -1,11 +1,12 @@
 package com.android.go.sopt.winey.presentation.main.feed.upload.loading
 
+import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import com.android.go.sopt.winey.R
 import com.android.go.sopt.winey.databinding.ActivityLoadingBinding
+import com.android.go.sopt.winey.presentation.main.MainActivity
 import com.android.go.sopt.winey.util.binding.BindingActivity
-import timber.log.Timber
 
 class LoadingActivity : BindingActivity<ActivityLoadingBinding>(R.layout.activity_loading) {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,13 +25,11 @@ class LoadingActivity : BindingActivity<ActivityLoadingBinding>(R.layout.activit
 
         for (idx in amountRange.indices) {
             if (idx == amountRange.size - 1) {
-                Timber.e("last: ${itemCategories[idx]}")
                 binding.saveItem = itemCategories[idx]
                 return
             }
 
             if (amount >= amountRange[idx] && amount < amountRange[idx + 1]) {
-                Timber.e(itemCategories[idx])
                 binding.saveItem = itemCategories[idx]
                 return
             }
@@ -39,8 +38,15 @@ class LoadingActivity : BindingActivity<ActivityLoadingBinding>(R.layout.activit
 
     private fun delayMillis() {
         Handler().postDelayed({
-            finish()
+            navigateMainScreen()
         }, DELAY_TIME)
+    }
+
+    private fun navigateMainScreen() {
+        Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(this)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/photo/PhotoFragment.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/photo/PhotoFragment.kt
@@ -51,7 +51,7 @@ class PhotoFragment : BindingFragment<FragmentPhotoBinding>(R.layout.fragment_ph
 
     private fun displaySelectedImage(imageUri: Uri) {
         binding.ivUploadPhoto.load(imageUri) {
-            transformations(RoundedCornersTransformation(20f))
+            transformations(RoundedCornersTransformation(10f))
         }
     }
 

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/photo/PhotoFragment.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/photo/PhotoFragment.kt
@@ -1,13 +1,10 @@
 package com.android.go.sopt.winey.presentation.main.feed.upload.photo
 
-import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
-import coil.load
-import coil.transform.RoundedCornersTransformation
 import com.android.go.sopt.winey.R
 import com.android.go.sopt.winey.databinding.FragmentPhotoBinding
 import com.android.go.sopt.winey.presentation.main.feed.upload.content.ContentFragment
@@ -33,10 +30,9 @@ class PhotoFragment : BindingFragment<FragmentPhotoBinding>(R.layout.fragment_ph
                     return@registerForActivityResult
                 }
 
-                displaySelectedImage(imageUri)
                 viewModel.apply {
-                    updateImageUri(imageUri)
-                    activateNextButton()
+                    updatePhotoSelectState() // 버튼 활성화를 위해서
+                    updateImageUri(imageUri) // 바인딩 어댑터 적용
                 }
             }
 
@@ -47,12 +43,6 @@ class PhotoFragment : BindingFragment<FragmentPhotoBinding>(R.layout.fragment_ph
 
     private fun displayDefaultImage() {
         binding.ivUploadPhoto.setImageResource(R.drawable.img_upload_photo)
-    }
-
-    private fun displaySelectedImage(imageUri: Uri) {
-        binding.ivUploadPhoto.load(imageUri) {
-            transformations(RoundedCornersTransformation(10f))
-        }
     }
 
     private fun initNextButtonClickListener() {

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/photo/PhotoViewModel.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/upload/photo/PhotoViewModel.kt
@@ -6,17 +6,17 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
 class PhotoViewModel : ViewModel() {
+    private val _photoSelected = MutableLiveData<Boolean>()
+    val photoSelected: LiveData<Boolean> get() = _photoSelected
+
     private val _imageUri = MutableLiveData<Uri>()
     val imageUri: LiveData<Uri> get() = _imageUri
 
-    private val _isUploaded = MutableLiveData<Boolean>()
-    val isUploaded: LiveData<Boolean> get() = _isUploaded
-
-    fun updateImageUri(imageUri: Uri){
-        _imageUri.value = imageUri
+    fun updatePhotoSelectState() {
+        _photoSelected.value = true
     }
 
-    fun activateNextButton() {
-        _isUploaded.value = true
+    fun updateImageUri(imageUri: Uri) {
+        _imageUri.value = imageUri
     }
 }

--- a/app/src/main/java/com/android/go/sopt/winey/util/UriToRequestBody.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/util/UriToRequestBody.kt
@@ -1,0 +1,59 @@
+package com.android.go.sopt.winey.util
+
+import android.content.Context
+import android.database.sqlite.SQLiteBindOrColumnIndexOutOfRangeException
+import android.net.Uri
+import android.provider.MediaStore
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okio.BufferedSink
+import okio.source
+import timber.log.Timber
+
+class UriToRequestBody(
+    context: Context,
+    private val imageUri: Uri
+) : RequestBody() {
+    private val contentResolver = context.contentResolver
+    private var fileName = ""
+    private var size = -1L
+
+    init {
+        try {
+            contentResolver.query(
+                imageUri,
+                arrayOf(MediaStore.Images.Media.SIZE, MediaStore.Images.Media.DISPLAY_NAME),
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    size = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.SIZE))
+                    fileName = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DISPLAY_NAME))
+                }
+            }
+        } catch (e: SQLiteBindOrColumnIndexOutOfRangeException) {
+            Timber.e(e.message)
+        }
+    }
+
+    override fun contentType(): MediaType? =
+        contentResolver.getType(imageUri)?.toMediaTypeOrNull()
+
+    override fun writeTo(sink: BufferedSink) {
+        try {
+            contentResolver.openInputStream(imageUri).use { inputStream ->
+                val source = inputStream?.source()
+                if (source != null) sink.writeAll(source)
+            }
+        } catch (e: IllegalStateException) {
+            "Couldn't open content URI for reading: $imageUri"
+        }
+    }
+
+    override fun contentLength(): Long = size
+
+    fun toFormData() = MultipartBody.Part.createFormData("feedImage", fileName, this)
+}

--- a/app/src/main/java/com/android/go/sopt/winey/util/binding/BindingAdapter.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/util/binding/BindingAdapter.kt
@@ -1,5 +1,7 @@
 package com.android.go.sopt.winey.util.binding
 
+import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
@@ -20,7 +22,7 @@ fun applyNumberFormat(view: TextView, amount: Long) {
     view.text = formattedValue
 }
 
-@BindingAdapter("setAmount","setPrefix","setSuffix", requireAll = false)
+@BindingAdapter("setAmount", "setPrefix", "setSuffix", requireAll = false)
 fun TextView.setFormattedNumber(amount: Long, prefix: String?, suffix: String?) {
     val pre = prefix ?: ""
     val suf = suffix ?: ""
@@ -37,3 +39,17 @@ fun loadImager(view: ImageView, imageurl: String) {
         transformations(RoundedCornersTransformation(10F))
     }
 }
+
+@BindingAdapter("setImageUriWithCoil", "setDefaultDrawable")
+fun ImageView.setRoundedImage(imageUri: Uri?, drawable: Drawable) {
+    if (imageUri == null) {
+        this.setImageDrawable(drawable)
+        return
+    }
+
+    load(imageUri) {
+        transformations(RoundedCornersTransformation(10f))
+    }
+}
+
+

--- a/app/src/main/res/layout/fragment_amount.xml
+++ b/app/src/main/res/layout/fragment_amount.xml
@@ -95,8 +95,6 @@
             android:inputType="numberDecimal"
             android:hint="@string/upload_amount_hint_text"
             android:maxLines="1"
-            android:paddingVertical="12dp"
-            android:paddingStart="18dp"
             android:paddingEnd="38dp"
             android:text="@={vm._amount}"
             android:textAppearance="@style/TextAppearance.WINEY.Headline_b_24_xxl"

--- a/app/src/main/res/layout/fragment_amount.xml
+++ b/app/src/main/res/layout/fragment_amount.xml
@@ -93,7 +93,7 @@
             android:gravity="center_vertical|end"
             android:importantForAutofill="no"
             android:inputType="numberDecimal"
-            android:maxLength="@{vm.MAX_AMOUNT_LENGTH}"
+            android:hint="@string/upload_amount_hint_text"
             android:maxLines="1"
             android:paddingVertical="12dp"
             android:paddingStart="18dp"

--- a/app/src/main/res/layout/fragment_photo.xml
+++ b/app/src/main/res/layout/fragment_photo.xml
@@ -84,16 +84,17 @@
 
         <ImageView
             android:id="@+id/iv_upload_photo"
+            setDefaultDrawable="@{@drawable/img_upload_photo}"
+            setImageUriWithCoil="@{vm.imageUri}"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginHorizontal="16dp"
             android:layout_marginTop="22dp"
-            android:scaleType="fitXY"
-            android:src="@{vm.imageUri, default=@drawable/img_upload_photo}"
             app:layout_constraintDimensionRatio="H, 2:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_photo_detail" />
+            app:layout_constraintTop_toBottomOf="@id/tv_photo_detail"
+            tools:src="@drawable/img_upload_photo" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_photo_next"
@@ -102,7 +103,7 @@
             android:layout_marginHorizontal="16dp"
             android:layout_marginBottom="14dp"
             android:background="@drawable/sel_upload_next_btn_bg_color"
-            android:enabled="@{vm.isUploaded ? true : false, default=false}"
+            android:enabled="@{vm.photoSelected ? true : false, default=false}"
             android:stateListAnimator="@null"
             android:text="@string/upload_next_btn_text"
             android:textAppearance="@style/TextAppearance.WINEY.body_m_16"

--- a/app/src/main/res/layout/fragment_photo.xml
+++ b/app/src/main/res/layout/fragment_photo.xml
@@ -84,12 +84,13 @@
 
         <ImageView
             android:id="@+id/iv_upload_photo"
-            android:layout_width="375dp"
+            android:layout_width="0dp"
             android:layout_height="0dp"
+            android:layout_marginHorizontal="16dp"
             android:layout_marginTop="22dp"
-            android:scaleType="fitCenter"
+            android:scaleType="fitXY"
             android:src="@{vm.imageUri, default=@drawable/img_upload_photo}"
-            app:layout_constraintDimensionRatio="16:9"
+            app:layout_constraintDimensionRatio="H, 2:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_photo_detail" />

--- a/app/src/main/res/layout/item_myfeed_post.xml
+++ b/app/src/main/res/layout/item_myfeed_post.xml
@@ -58,7 +58,7 @@
 
         <ImageView
             android:id="@+id/iv_myfeed_image"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginHorizontal="16dp"
             android:layout_marginTop="10dp"
@@ -68,7 +68,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/iv_myfeed_profilephoto"
-            tools:src="@drawable/img_wineyfeed_default" />
+            tools:src="@drawable/img_feed_default" />
 
         <TextView
             android:id="@+id/tv_myfeed_money"

--- a/app/src/main/res/layout/item_wineyfeed_post.xml
+++ b/app/src/main/res/layout/item_wineyfeed_post.xml
@@ -65,7 +65,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/iv_wineyfeed_profilephoto"
-            tools:src="@drawable/img_wineyfeed_default" />
+            tools:src="@drawable/img_feed_default" />
 
         <TextView
             android:id="@+id/tv_wineyfeed_money"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,4 +89,5 @@
 
     <!-- recommend -->
     <string name="recommend_discount">%s 절약</string>
+    <string name="upload_amount_hint_text">0</string>
 </resources>


### PR DESCRIPTION
- closed #68

## 📝 Work Description

-  업로드 직후 로딩 애니메이션 끝나면 위니 피드로 전환
-  절약 내용: 공백 포함 6~36자
-  절약 금액: 1~9,999,999
-  사진 업로드 시, 리사이즈 하지 않고 그대로 전송 (최대 5MB)
-  갤러리에서 선택한 이미지의 uri -> 바인딩 어댑터에서 coil 적용 (uri가 널이면 디폴트 drawable 표시)
-  금액 문자열이 비어있으면 replace 적용하지 않도록 수정

## 📣 To Reviewers

코드 확인 부탁드려요! 
