### PR TITLE
[feat] 상세 피드 / 피드 좋아요, 삭제, 신고 구현

### DIFF
--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/MainActivity.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.onEach
 class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
     private val mainViewModel by viewModels<MainViewModel>()
     private val isUploadSuccess by lazy { intent.extras?.getBoolean(EXTRA_UPLOAD_KEY, false) }
-
+    private val isDeleteSuccess by lazy { intent.extras?.getBoolean(EXTRA_DELETE_KEY, false) }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -40,6 +40,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
         setupLogoutState()
         showUploadSuccessSnackbar()
+        showDeleteSuccessSnackbar()
     }
 
     private fun initFragment() {
@@ -54,6 +55,12 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     private fun showUploadSuccessSnackbar() {
         if (isUploadSuccess != null && isUploadSuccess == true) {
             wineySnackbar(binding.root, true, stringOf(R.string.snackbar_upload_success))
+        }
+    }
+
+    private fun showDeleteSuccessSnackbar() {
+        if (isDeleteSuccess != null && isDeleteSuccess == true) {
+            wineySnackbar(binding.root, true, stringOf(R.string.snackbar_feed_delete_success))
         }
     }
 
@@ -119,5 +126,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     companion object {
         private const val EXTRA_UPLOAD_KEY = "upload"
+        private const val EXTRA_DELETE_KEY = "delete"
     }
 }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/MainActivity.kt
@@ -28,6 +28,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     private val mainViewModel by viewModels<MainViewModel>()
     private val isUploadSuccess by lazy { intent.extras?.getBoolean(EXTRA_UPLOAD_KEY, false) }
     private val isDeleteSuccess by lazy { intent.extras?.getBoolean(EXTRA_DELETE_KEY, false) }
+    private val isReportSuccess by lazy { intent.extras?.getBoolean(EXTRA_REPORT_KEY, false) }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -39,8 +40,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         syncBottomNavigationSelection()
 
         setupLogoutState()
-        showUploadSuccessSnackbar()
-        showDeleteSuccessSnackbar()
+        showSuccessSnackBar()
     }
 
     private fun initFragment() {
@@ -52,15 +52,15 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         }
     }
 
-    private fun showUploadSuccessSnackbar() {
+    private fun showSuccessSnackBar(){
         if (isUploadSuccess != null && isUploadSuccess == true) {
             wineySnackbar(binding.root, true, stringOf(R.string.snackbar_upload_success))
         }
-    }
-
-    private fun showDeleteSuccessSnackbar() {
         if (isDeleteSuccess != null && isDeleteSuccess == true) {
             wineySnackbar(binding.root, true, stringOf(R.string.snackbar_feed_delete_success))
+        }
+        if (isReportSuccess != null && isReportSuccess == true) {
+            wineySnackbar(binding.root, true, stringOf(R.string.snackbar_report_success))
         }
     }
 
@@ -127,5 +127,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     companion object {
         private const val EXTRA_UPLOAD_KEY = "upload"
         private const val EXTRA_DELETE_KEY = "delete"
+        private const val EXTRA_REPORT_KEY = "report"
     }
 }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/MainActivity.kt
@@ -52,7 +52,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         }
     }
 
-    private fun showSuccessSnackBar(){
+    private fun showSuccessSnackBar() {
         if (isUploadSuccess != null && isUploadSuccess == true) {
             wineySnackbar(binding.root, true, stringOf(R.string.snackbar_upload_success))
         }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/WineyFeedAdapter.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/WineyFeedAdapter.kt
@@ -72,24 +72,6 @@ class WineyFeedAdapter(
         holder.onBind(getItem(position))
     }
 
-    fun updateLikeStatus(feedId: Int, isLiked: Boolean) {
-        currentData.let { data ->
-            val index = data.indexOfFirst { it?.feedId == feedId }
-            if (index == -1) {
-                return
-            }
-            data[index]?.let { item ->
-                item.isLiked = isLiked
-                if (isLiked) {
-                    item.likes++
-                } else {
-                    item.likes--
-                }
-                notifyItemChanged(index)
-            }
-        }
-    }
-
     companion object {
         private val diffUtil = ItemDiffCallback<WineyFeed>(
             onItemsTheSame = { old, new -> old.feedId == new.feedId },

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/WineyFeedAdapter.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/WineyFeedAdapter.kt
@@ -15,7 +15,7 @@ import com.android.go.sopt.winey.util.view.setOnSingleClickListener
 class WineyFeedAdapter(
     private val likeButtonClick: (feedId: Int, isLiked: Boolean) -> Unit,
     private val showPopupMenu: (View, WineyFeed) -> Unit,
-    private val toFeedDetail: (feedId: Int, writerLevel: Int) -> Unit
+    private val toFeedDetail: (feedId: Int, writerId: Int) -> Unit
 ) : PagingDataAdapter<WineyFeed, WineyFeedAdapter.WineyFeedViewHolder>(diffUtil) {
     private val currentData: ItemSnapshotList<WineyFeed>
         get() = snapshot()

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/WineyFeedFragment.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/WineyFeedFragment.kt
@@ -49,7 +49,6 @@ import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import javax.inject.Inject
 
-
 @AndroidEntryPoint
 class WineyFeedFragment :
     BindingFragment<FragmentWineyFeedBinding>(R.layout.fragment_winey_feed) {
@@ -101,7 +100,7 @@ class WineyFeedFragment :
 
     private fun showPopupMenu(view: View, wineyFeed: WineyFeed) {
         val inflater = LayoutInflater.from(requireContext())
-        val popupView = inflater.inflate(com.android.go.sopt.winey.R.layout.menu_wineyfeed, null)
+        val popupView = inflater.inflate(R.layout.menu_wineyfeed, null)
         val popupWindow = PopupWindow(
             popupView,
             WindowManager.LayoutParams.WRAP_CONTENT,
@@ -110,9 +109,9 @@ class WineyFeedFragment :
         )
 
         val menuDelete =
-            popupView.findViewById<TextView>(com.android.go.sopt.winey.R.id.tv_popup_delete)
+            popupView.findViewById<TextView>(R.id.tv_popup_delete)
         val menuReport =
-            popupView.findViewById<TextView>(com.android.go.sopt.winey.R.id.tv_popup_report)
+            popupView.findViewById<TextView>(R.id.tv_popup_report)
 
         if (wineyFeed.userId == runBlocking { dataStoreRepository.getUserId().first() }) {
             menuReport.isVisible = false
@@ -131,7 +130,7 @@ class WineyFeedFragment :
     private fun refreshWineyFeed() {
         val fragmentManager = parentFragmentManager
         fragmentManager.beginTransaction().apply {
-            replace(com.android.go.sopt.winey.R.id.fcv_main, WineyFeedFragment())
+            replace(R.id.fcv_main, WineyFeedFragment())
             commit()
         }
     }
@@ -257,11 +256,11 @@ class WineyFeedFragment :
 
     private inline fun <reified T : Fragment> navigateTo() {
         parentFragmentManager.commit {
-            replace<T>(com.android.go.sopt.winey.R.id.fcv_main, T::class.simpleName)
+            replace<T>(R.id.fcv_main, T::class.simpleName)
         }
         val bottomNav: BottomNavigationView =
-            requireActivity().findViewById(com.android.go.sopt.winey.R.id.bnv_main)
-        bottomNav.selectedItemId = com.android.go.sopt.winey.R.id.menu_mypage
+            requireActivity().findViewById(R.id.bnv_main)
+        bottomNav.selectedItemId = R.id.menu_mypage
     }
 
     private fun setSwipeRefreshListener() {
@@ -281,42 +280,6 @@ class WineyFeedFragment :
         intent.putExtra(KEY_FEED_ID, feedId)
         intent.putExtra(KEY_FEED_WRITER_ID, writerId)
         startActivity(intent)
-    }
-
-
-    override fun onStart() {
-        super.onStart()
-        Log.d("Fragment Lifecycle", "onStart 호출됨")
-    }
-
-    override fun onResume() {
-        super.onResume()
-        viewModel.getWineyFeed()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        Log.d("Fragment Lifecycle", "onPause 호출됨")
-    }
-
-    override fun onStop() {
-        super.onStop()
-        Log.d("Fragment Lifecycle", "onStop 호출됨")
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        Log.d("Fragment Lifecycle", "onDestroyView 호출됨")
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        Log.d("Fragment Lifecycle", "onDestroy 호출됨")
-    }
-
-    override fun onDetach() {
-        super.onDetach()
-        Log.d("Fragment Lifecycle", "onDetach 호출됨")
     }
 
     companion object {

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/WineyFeedFragment.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/WineyFeedFragment.kt
@@ -2,6 +2,7 @@ package com.android.go.sopt.winey.presentation.main.feed
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.WindowManager
@@ -47,8 +48,10 @@ import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import javax.inject.Inject
 
+
 @AndroidEntryPoint
-class WineyFeedFragment : BindingFragment<FragmentWineyFeedBinding>(R.layout.fragment_winey_feed) {
+class WineyFeedFragment :
+    BindingFragment<FragmentWineyFeedBinding>(R.layout.fragment_winey_feed) {
     private val viewModel by viewModels<WineyFeedViewModel>()
     private val mainViewModel by activityViewModels<MainViewModel>()
     private lateinit var wineyFeedAdapter: WineyFeedAdapter
@@ -60,6 +63,7 @@ class WineyFeedFragment : BindingFragment<FragmentWineyFeedBinding>(R.layout.fra
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        Log.d("Fragment Lifecycle", "onViewCreated 호출됨")
         initAdapter()
         setSwipeRefreshListener()
         initFabClickListener()
@@ -87,7 +91,7 @@ class WineyFeedFragment : BindingFragment<FragmentWineyFeedBinding>(R.layout.fra
 
     private fun showPopupMenu(view: View, wineyFeed: WineyFeed) {
         val inflater = LayoutInflater.from(requireContext())
-        val popupView = inflater.inflate(R.layout.menu_wineyfeed, null)
+        val popupView = inflater.inflate(com.android.go.sopt.winey.R.layout.menu_wineyfeed, null)
         val popupWindow = PopupWindow(
             popupView,
             WindowManager.LayoutParams.WRAP_CONTENT,
@@ -95,8 +99,10 @@ class WineyFeedFragment : BindingFragment<FragmentWineyFeedBinding>(R.layout.fra
             true
         )
 
-        val menuDelete = popupView.findViewById<TextView>(R.id.tv_popup_delete)
-        val menuReport = popupView.findViewById<TextView>(R.id.tv_popup_report)
+        val menuDelete =
+            popupView.findViewById<TextView>(com.android.go.sopt.winey.R.id.tv_popup_delete)
+        val menuReport =
+            popupView.findViewById<TextView>(com.android.go.sopt.winey.R.id.tv_popup_report)
 
         if (wineyFeed.userId == runBlocking { dataStoreRepository.getUserId().first() }) {
             menuReport.isVisible = false
@@ -115,7 +121,7 @@ class WineyFeedFragment : BindingFragment<FragmentWineyFeedBinding>(R.layout.fra
     private fun refreshWineyFeed() {
         val fragmentManager = parentFragmentManager
         fragmentManager.beginTransaction().apply {
-            replace(R.id.fcv_main, WineyFeedFragment())
+            replace(com.android.go.sopt.winey.R.id.fcv_main, WineyFeedFragment())
             commit()
         }
     }
@@ -178,10 +184,7 @@ class WineyFeedFragment : BindingFragment<FragmentWineyFeedBinding>(R.layout.fra
             when (state) {
                 is UiState.Success -> {
                     initGetFeedStateObserver()
-                    wineyFeedAdapter.updateLikeStatus(
-                        state.data.data.feedId,
-                        state.data.data.isLiked
-                    )
+                    wineyFeedAdapter.refresh()
                 }
 
                 is UiState.Failure -> {
@@ -236,10 +239,11 @@ class WineyFeedFragment : BindingFragment<FragmentWineyFeedBinding>(R.layout.fra
 
     private inline fun <reified T : Fragment> navigateTo() {
         parentFragmentManager.commit {
-            replace<T>(R.id.fcv_main, T::class.simpleName)
+            replace<T>(com.android.go.sopt.winey.R.id.fcv_main, T::class.simpleName)
         }
-        val bottomNav: BottomNavigationView = requireActivity().findViewById(R.id.bnv_main)
-        bottomNav.selectedItemId = R.id.menu_mypage
+        val bottomNav: BottomNavigationView =
+            requireActivity().findViewById(com.android.go.sopt.winey.R.id.bnv_main)
+        bottomNav.selectedItemId = com.android.go.sopt.winey.R.id.menu_mypage
     }
 
     private fun setSwipeRefreshListener() {
@@ -259,6 +263,42 @@ class WineyFeedFragment : BindingFragment<FragmentWineyFeedBinding>(R.layout.fra
         intent.putExtra(KEY_FEED_ID, feedId)
         intent.putExtra(KEY_WRITER_LV, writerLevel)
         startActivity(intent)
+    }
+
+
+    override fun onStart() {
+        super.onStart()
+        Log.d("Fragment Lifecycle", "onStart 호출됨")
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.getWineyFeed()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        Log.d("Fragment Lifecycle", "onPause 호출됨")
+    }
+
+    override fun onStop() {
+        super.onStop()
+        Log.d("Fragment Lifecycle", "onStop 호출됨")
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        Log.d("Fragment Lifecycle", "onDestroyView 호출됨")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d("Fragment Lifecycle", "onDestroy 호출됨")
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        Log.d("Fragment Lifecycle", "onDetach 호출됨")
     }
 
     companion object {

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -175,7 +175,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
             stringOf(R.string.comment_delete_dialog_negative_button),
             stringOf(R.string.comment_delete_dialog_positive_button),
             handleNegativeButton = {},
-            handlePositiveButton = { /* todo: 댓글 삭제하기 */}
+            handlePositiveButton = { /* todo: 댓글 삭제하기 */ }
         )
         dialog.show(supportFragmentManager, TAG_COMMENT_DELETE_DIALOG)
     }
@@ -200,7 +200,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
             stringOf(R.string.report_dialog_negative_button),
             stringOf(R.string.report_dialog_positive_button),
             handleNegativeButton = {},
-            handlePositiveButton = { /* todo: 댓글 신고하기 */ }
+            handlePositiveButton = { navigateToMain(EXTRA_REPORT_KEY) }
         )
         dialog.show(supportFragmentManager, TAG_COMMENT_REPORT_DIALOG)
     }
@@ -259,7 +259,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         viewModel.deleteFeedDetailState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
                 is UiState.Success -> {
-                    navigateToMain()
+                    navigateToMain(EXTRA_DELETE_KEY)
                 }
 
                 is UiState.Failure -> {
@@ -309,10 +309,10 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         }.launchIn(lifecycleScope)
     }
 
-    private fun navigateToMain() {
+    private fun navigateToMain(extraKey: String) {
         Intent(this, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
-            putExtra(EXTRA_DELETE_KEY, true)
+            putExtra(extraKey, true)
             startActivity(this)
         }
     }
@@ -329,5 +329,6 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         private const val MSG_DETAIL_ERROR = "ERROR"
 
         private const val EXTRA_DELETE_KEY = "delete"
+        private const val EXTRA_REPORT_KEY = "report"
     }
 }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -209,7 +209,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
             Timber.e("DETAIL FEED IS NULL")
             return
         }
-        detailFeedAdapter =
+        _detailFeedAdapter =
             DetailFeedAdapter(
                 detailFeed,
                 postLike = { feedId, isLiked ->
@@ -250,7 +250,6 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
                 }
 
                 else -> {
-
                 }
             }
         }.launchIn(lifecycleScope)

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -302,9 +302,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
                     snackBar(binding.root) { state.msg }
                 }
 
-                else -> {
-
-                }
+                else -> Timber.tag("failure").e(MSG_DETAIL_ERROR)
             }
         }.launchIn(lifecycleScope)
     }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -97,7 +97,6 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
             when (state) {
                 is UiState.Success -> {
                     viewModel.getFeedDetail(feedId)
-
                 }
 
                 is UiState.Failure -> {

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -36,6 +36,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         viewModel.getFeedDetail(feedId)
         initGetFeedDetailObserver()
         initBackButtonClickListener()
+        initPostLikeStateObserver()
     }
 
     private fun initGetFeedDetailObserver() {
@@ -62,7 +63,13 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
             Timber.e("DETAIL FEED IS NULL")
             return
         }
-        detailFeedAdapter = DetailFeedAdapter(detailFeed)
+        detailFeedAdapter =
+            DetailFeedAdapter(
+                detailFeed,
+                postLike = { feedId, isLiked ->
+                    viewModel.likeFeed(feedId, isLiked)
+                }
+            )
     }
 
     private fun switchCommentContainer(commentList: List<Comment>?) {
@@ -83,6 +90,25 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         binding.ivDetailBack.setOnClickListener {
             finish()
         }
+    }
+
+    private fun initPostLikeStateObserver() {
+        viewModel.postFeedDetailLikeState.flowWithLifecycle(lifecycle).onEach { state ->
+            when (state) {
+                is UiState.Success -> {
+                    viewModel.getFeedDetail(feedId)
+
+                }
+
+                is UiState.Failure -> {
+                    snackBar(binding.root) { state.msg }
+                }
+
+                else -> {
+
+                }
+            }
+        }.launchIn(lifecycleScope)
     }
 
     companion object {

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -1,6 +1,7 @@
 package com.android.go.sopt.winey.presentation.main.feed.detail
 
 import CommentAdapter
+import android.content.Intent
 import android.os.Bundle
 import android.view.Gravity
 import android.view.View
@@ -13,9 +14,11 @@ import com.android.go.sopt.winey.databinding.ActivityDetailBinding
 import com.android.go.sopt.winey.domain.entity.Comment
 import com.android.go.sopt.winey.domain.entity.DetailFeed
 import com.android.go.sopt.winey.domain.repository.DataStoreRepository
+import com.android.go.sopt.winey.presentation.main.MainActivity
 import com.android.go.sopt.winey.util.binding.BindingActivity
 import com.android.go.sopt.winey.util.context.snackBar
 import com.android.go.sopt.winey.util.context.stringOf
+import com.android.go.sopt.winey.util.context.wineySnackbar
 import com.android.go.sopt.winey.util.fragment.WineyDialogFragment
 import com.android.go.sopt.winey.util.view.UiState
 import com.android.go.sopt.winey.util.view.WineyPopupMenu
@@ -62,19 +65,36 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
     private fun initCommentAdapter() {
         _commentAdapter = CommentAdapter(
             onPopupMenuClicked = { anchorView, commentAuthorId ->
-                showPopupMenu(anchorView, commentAuthorId)
+                showCommentPopupMenu(anchorView, commentAuthorId)
             }
         )
     }
 
-    private fun showPopupMenu(anchorView: View, commentAuthorId: Int) {
+    private fun initDetailFeedAdapter(detailFeed: DetailFeed?) {
+        if (detailFeed == null) {
+            Timber.e("DETAIL FEED IS NULL")
+            return
+        }
+        _detailFeedAdapter =
+            DetailFeedAdapter(
+                detailFeed,
+                onLikeButtonClicked = { feedId, isLiked ->
+                    viewModel.likeFeed(feedId, isLiked)
+                },
+                onPopupMenuClicked = { anchorView ->
+                    showFeedPopupMenu(anchorView)
+                }
+            )
+    }
+
+    private fun showCommentPopupMenu(anchorView: View, commentAuthorId: Int) {
         lifecycleScope.launch {
             val currentUserId = dataStoreRepository.getUserId().first()
 
             if (isMyFeed(currentUserId)) {
                 if (isMyComment(currentUserId, commentAuthorId)) {
                     // 내 댓글 삭제
-                    showDeletePopupMenu(anchorView)
+                    showCommentDeletePopupMenu(anchorView)
                 } else {
                     // 방문자 댓글 삭제/신고
                     showAllPopupMenu(anchorView)
@@ -82,7 +102,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
             } else {
                 if (isMyComment(currentUserId, commentAuthorId)) {
                     // 내 댓글 삭제
-                    showDeletePopupMenu(anchorView)
+                    showCommentDeletePopupMenu(anchorView)
                 } else {
                     // 다른 사람 댓글 신고
                     showReportPopupMenu(anchorView)
@@ -91,10 +111,30 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         }
     }
 
-    private fun showDeletePopupMenu(anchorView: View) {
+    private fun showFeedPopupMenu(anchorView: View) {
+        lifecycleScope.launch {
+            val currentUserId = dataStoreRepository.getUserId().first()
+            if (isMyFeed(currentUserId)) {
+                showFeedDeletePopupMenu(anchorView)
+            } else {
+                showReportPopupMenu(anchorView)
+            }
+        }
+    }
+
+    private fun showCommentDeletePopupMenu(anchorView: View) {
         val deleteTitle = listOf(stringOf(R.string.popup_delete_title))
         WineyPopupMenu(context = anchorView.context, titles = deleteTitle) { _, _, _ ->
             showCommentDeleteDialog()
+        }.apply {
+            showCustomPosition(anchorView)
+        }
+    }
+
+    private fun showFeedDeletePopupMenu(anchorView: View) {
+        val deleteTitle = listOf(stringOf(R.string.popup_delete_title))
+        WineyPopupMenu(context = anchorView.context, titles = deleteTitle) { _, _, _ ->
+            showFeedDeleteDialog()
         }.apply {
             showCustomPosition(anchorView)
         }
@@ -135,9 +175,22 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
             stringOf(R.string.comment_delete_dialog_negative_button),
             stringOf(R.string.comment_delete_dialog_positive_button),
             handleNegativeButton = {},
-            handlePositiveButton = { /* todo: 댓글 삭제하기 */ }
+            handlePositiveButton = { /* todo: 댓글 삭제하기 */}
         )
         dialog.show(supportFragmentManager, TAG_COMMENT_DELETE_DIALOG)
+    }
+
+    private fun showFeedDeleteDialog() {
+        val dialog = WineyDialogFragment(
+            stringOf(R.string.feed_delete_dialog_title),
+            stringOf(R.string.feed_delete_dialog_subtitle),
+            stringOf(R.string.comment_delete_dialog_negative_button),
+            stringOf(R.string.comment_delete_dialog_positive_button),
+            handleNegativeButton = {},
+            handlePositiveButton = { viewModel.deleteFeed(feedId) }
+        )
+        dialog.show(supportFragmentManager, TAG_COMMENT_DELETE_DIALOG)
+        initDeleteFeedStateObserver()
     }
 
     private fun showCommentReportDialog() {
@@ -179,8 +232,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
                         snackBar(binding.root) { state.msg }
                     }
 
-                    else -> {
-                    }
+                    else -> Timber.tag("failure").e(MSG_DETAIL_ERROR)
                 }
             }.launchIn(lifecycleScope)
     }
@@ -198,24 +250,25 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
                     snackBar(binding.root) { state.msg }
                 }
 
-                else -> {
-                }
+                else -> Timber.tag("failure").e(MSG_DETAIL_ERROR)
             }
         }.launchIn(lifecycleScope)
     }
 
-    private fun initDetailFeedAdapter(detailFeed: DetailFeed?) {
-        if (detailFeed == null) {
-            Timber.e("DETAIL FEED IS NULL")
-            return
-        }
-        _detailFeedAdapter =
-            DetailFeedAdapter(
-                detailFeed,
-                postLike = { feedId, isLiked ->
-                    viewModel.likeFeed(feedId, isLiked)
+    private fun initDeleteFeedStateObserver() {
+        viewModel.deleteFeedDetailState.flowWithLifecycle(lifecycle).onEach { state ->
+            when (state) {
+                is UiState.Success -> {
+                    navigateToMain()
                 }
-            )
+
+                is UiState.Failure -> {
+                    wineySnackbar(binding.root, false, stringOf(R.string.snackbar_delete_fail))
+                }
+
+                else -> Timber.tag("failure").e(MSG_DETAIL_ERROR)
+            }
+        }.launchIn(lifecycleScope)
     }
 
     private fun switchCommentContainer(commentList: List<Comment>?) {
@@ -250,9 +303,18 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
                 }
 
                 else -> {
+
                 }
             }
         }.launchIn(lifecycleScope)
+    }
+
+    private fun navigateToMain() {
+        Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra(EXTRA_DELETE_KEY, true)
+            startActivity(this)
+        }
     }
 
     companion object {
@@ -263,5 +325,9 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         private const val TAG_COMMENT_REPORT_DIALOG = "COMMENT_REPORT_DIALOG"
 
         private const val POPUP_MENU_OFFSET = 65
+
+        private const val MSG_DETAIL_ERROR = "ERROR"
+
+        private const val EXTRA_DELETE_KEY = "delete"
     }
 }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailFeedAdapter.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailFeedAdapter.kt
@@ -49,7 +49,6 @@ class DetailFeedAdapter(
                 btnDetailMore.setOnSingleClickListener { view ->
                     onPopupMenuClicked(view)
                 }
-
             }
         }
     }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailFeedAdapter.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailFeedAdapter.kt
@@ -5,20 +5,18 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.android.go.sopt.winey.databinding.ItemDetailFeedBinding
 import com.android.go.sopt.winey.domain.entity.DetailFeed
+import com.android.go.sopt.winey.util.view.setOnSingleClickListener
 
 class DetailFeedAdapter(
-    private val detailFeed: DetailFeed
+    private val detailFeed: DetailFeed,
+    private val postLike: (feedId: Int, isLiked: Boolean) -> Unit
 ) :
     RecyclerView.Adapter<DetailFeedAdapter.DetailFeedViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DetailFeedViewHolder {
-        return DetailFeedViewHolder(
-            ItemDetailFeedBinding.inflate(
-                LayoutInflater.from(parent.context),
-                parent,
-                false
-            )
-        )
+        val binding =
+            ItemDetailFeedBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return DetailFeedViewHolder(binding, postLike)
     }
 
     override fun onBindViewHolder(holder: DetailFeedViewHolder, position: Int) {
@@ -28,10 +26,19 @@ class DetailFeedAdapter(
     override fun getItemCount(): Int = FEED_ITEM_COUNT
 
     class DetailFeedViewHolder(
-        private val binding: ItemDetailFeedBinding
+        private val binding: ItemDetailFeedBinding,
+        private val postLike: (feedId: Int, isLiked: Boolean) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(data: DetailFeed) {
-            binding.data = data
+        fun bind(data: DetailFeed?) {
+            binding.apply {
+                this.data = data
+                if (data == null) {
+                    return
+                }
+                ivDetailLike.setOnSingleClickListener {
+                    postLike(data.feedId, !data.isLiked)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailFeedAdapter.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailFeedAdapter.kt
@@ -1,6 +1,7 @@
 package com.android.go.sopt.winey.presentation.main.feed.detail
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.android.go.sopt.winey.databinding.ItemDetailFeedBinding
@@ -9,14 +10,15 @@ import com.android.go.sopt.winey.util.view.setOnSingleClickListener
 
 class DetailFeedAdapter(
     private val detailFeed: DetailFeed,
-    private val postLike: (feedId: Int, isLiked: Boolean) -> Unit
+    private val onLikeButtonClicked: (feedId: Int, isLiked: Boolean) -> Unit,
+    private val onPopupMenuClicked: (View) -> Unit
 ) :
     RecyclerView.Adapter<DetailFeedAdapter.DetailFeedViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DetailFeedViewHolder {
         val binding =
             ItemDetailFeedBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return DetailFeedViewHolder(binding, postLike)
+        return DetailFeedViewHolder(binding, onLikeButtonClicked, onPopupMenuClicked)
     }
 
     override fun getItemCount(): Int = FEED_ITEM_COUNT
@@ -32,7 +34,8 @@ class DetailFeedAdapter(
 
     class DetailFeedViewHolder(
         private val binding: ItemDetailFeedBinding,
-        private val postLike: (feedId: Int, isLiked: Boolean) -> Unit
+        private val onLikeButtonClicked: (feedId: Int, isLiked: Boolean) -> Unit,
+        private val onPopupMenuClicked: (View) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(data: DetailFeed?) {
             binding.apply {
@@ -41,8 +44,12 @@ class DetailFeedAdapter(
                     return
                 }
                 ivDetailLike.setOnSingleClickListener {
-                    postLike(data.feedId, !data.isLiked)
+                    onLikeButtonClicked(data.feedId, !data.isLiked)
                 }
+                btnDetailMore.setOnSingleClickListener { view ->
+                    onPopupMenuClicked(view)
+                }
+
             }
         }
     }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailViewModel.kt
@@ -59,7 +59,6 @@ class DetailViewModel @Inject constructor(
     private val _postFeedDetailLikeState = MutableStateFlow<UiState<Like>>(UiState.Loading)
     val postFeedDetailLikeState: StateFlow<UiState<Like>> = _postFeedDetailLikeState.asStateFlow()
 
-
     fun likeFeed(feedId: Int, isLiked: Boolean) {
         val requestPostLikeDto = RequestPostLikeDto(isLiked)
         postLike(feedId, requestPostLikeDto)

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailViewModel.kt
@@ -59,6 +59,9 @@ class DetailViewModel @Inject constructor(
     private val _postFeedDetailLikeState = MutableStateFlow<UiState<Like>>(UiState.Loading)
     val postFeedDetailLikeState: StateFlow<UiState<Like>> = _postFeedDetailLikeState.asStateFlow()
 
+    val _deleteFeedDetailState = MutableStateFlow<UiState<Unit>>(UiState.Loading)
+    val deleteFeedDetailState: StateFlow<UiState<Unit>> = _deleteFeedDetailState.asStateFlow()
+
     fun likeFeed(feedId: Int, isLiked: Boolean) {
         val requestPostLikeDto = RequestPostLikeDto(isLiked)
         postLike(feedId, requestPostLikeDto)
@@ -100,6 +103,16 @@ class DetailViewModel @Inject constructor(
                     _postFeedDetailLikeState.emit(UiState.Success(response))
                 }
                 .onFailure { t -> handleFailureState(_postFeedDetailLikeState, t) }
+        }
+    }
+
+    fun deleteFeed(feedId: Int) {
+        viewModelScope.launch {
+            feedRepository.deleteFeed(feedId)
+                .onSuccess { response ->
+                    _deleteFeedDetailState.emit(UiState.Success(response))
+                }
+                .onFailure { t -> handleFailureState(_deleteFeedDetailState, t) }
         }
     }
 

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailViewModel.kt
@@ -2,7 +2,9 @@ package com.android.go.sopt.winey.presentation.main.feed.detail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.android.go.sopt.winey.data.model.remote.request.RequestPostLikeDto
 import com.android.go.sopt.winey.domain.entity.DetailFeed
+import com.android.go.sopt.winey.domain.entity.Like
 import com.android.go.sopt.winey.domain.repository.FeedRepository
 import com.android.go.sopt.winey.util.view.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -49,6 +51,15 @@ class DetailViewModel @Inject constructor(
     val getFeedDetailState: StateFlow<UiState<DetailFeed?>> =
         _getFeedDetailState.asStateFlow()
 
+    private val _postFeedDetailLikeState = MutableStateFlow<UiState<Like>>(UiState.Loading)
+    val postFeedDetailLikeState: StateFlow<UiState<Like>> = _postFeedDetailLikeState.asStateFlow()
+
+
+    fun likeFeed(feedId: Int, isLiked: Boolean) {
+        val requestPostLikeDto = RequestPostLikeDto(isLiked)
+        postLike(feedId, requestPostLikeDto)
+    }
+
     fun getFeedDetail(feedId: Int) {
         viewModelScope.launch {
             feedRepository.getFeedDetail(feedId)
@@ -56,6 +67,16 @@ class DetailViewModel @Inject constructor(
                     _getFeedDetailState.emit(UiState.Success(response))
                 }
                 .onFailure { t -> handleFailureState(_getFeedDetailState, t) }
+        }
+    }
+
+    private fun postLike(feedId: Int, requestPostLikeDto: RequestPostLikeDto) {
+        viewModelScope.launch {
+            feedRepository.postFeedLike(feedId, requestPostLikeDto)
+                .onSuccess { response ->
+                    _postFeedDetailLikeState.emit(UiState.Success(response))
+                }
+                .onFailure { t -> handleFailureState(_postFeedDetailLikeState, t) }
         }
     }
 

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedAdapter.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedAdapter.kt
@@ -62,7 +62,8 @@ class MyFeedAdapter(
         parent: ViewGroup,
         viewType: Int
     ): MyFeedViewHolder {
-        val binding = ItemMyfeedPostBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val binding =
+            ItemMyfeedPostBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return MyFeedViewHolder(binding, likeButtonClick, showPopupMenu, toFeedDetail)
     }
 
@@ -70,22 +71,6 @@ class MyFeedAdapter(
         holder.onBind(getItem(position))
     }
 
-    fun updateLikeStatus(feedId: Int, isLiked: Boolean) {
-        currentData.let { data ->
-            val index = data.indexOfFirst { it?.feedId == feedId }
-            if (index != -1) {
-                data[index]?.let { item ->
-                    item.isLiked = isLiked
-                    if (isLiked) {
-                        item.likes++
-                    } else {
-                        item.likes--
-                    }
-                    notifyItemChanged(index)
-                }
-            }
-        }
-    }
 
     companion object {
         private val diffUtil = ItemDiffCallback<WineyFeed>(

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedAdapter.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedAdapter.kt
@@ -15,7 +15,7 @@ import com.android.go.sopt.winey.util.view.setOnSingleClickListener
 class MyFeedAdapter(
     private val likeButtonClick: (feedId: Int, isLiked: Boolean) -> Unit,
     private val showPopupMenu: (View, WineyFeed) -> Unit,
-    private val toFeedDetail: (feedId: Int, writerLevel: Int) -> Unit
+    private val toFeedDetail: (feedId: Int, writerId: Int) -> Unit
 ) : PagingDataAdapter<WineyFeed, MyFeedAdapter.MyFeedViewHolder>(diffUtil) {
     private val currentData: ItemSnapshotList<WineyFeed>
         get() = snapshot()
@@ -24,7 +24,7 @@ class MyFeedAdapter(
         private val binding: ItemMyfeedPostBinding,
         private val onLikeButtonClick: (feedId: Int, isLiked: Boolean) -> Unit,
         private val showPopupMenu: (View, WineyFeed) -> Unit,
-        private val toFeedDetail: (feedId: Int, writerLevel: Int) -> Unit
+        private val toFeedDetail: (feedId: Int, writerId: Int) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
         fun onBind(data: WineyFeed?) {
             binding.apply {
@@ -40,7 +40,7 @@ class MyFeedAdapter(
                     showPopupMenu(view, data)
                 }
                 lMyfeedPost.setOnSingleClickListener {
-                    toFeedDetail(data.feedId, data.writerLevel)
+                    toFeedDetail(data.feedId, data.userId)
                 }
             }
         }

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedAdapter.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedAdapter.kt
@@ -71,7 +71,6 @@ class MyFeedAdapter(
         holder.onBind(getItem(position))
     }
 
-
     companion object {
         private val diffUtil = ItemDiffCallback<WineyFeed>(
             onItemsTheSame = { old, new -> old.feedId == new.feedId },

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedFragment.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedFragment.kt
@@ -162,10 +162,7 @@ class MyFeedFragment : BindingFragment<FragmentMyfeedBinding>(R.layout.fragment_
             when (state) {
                 is UiState.Success -> {
                     initGetFeedStateObserver()
-                    myFeedAdapter.updateLikeStatus(
-                        state.data.data.feedId,
-                        state.data.data.isLiked
-                    )
+                    myFeedAdapter.refresh()
                 }
 
                 is UiState.Failure -> {

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedFragment.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedFragment.kt
@@ -59,7 +59,7 @@ class MyFeedFragment : BindingFragment<FragmentMyfeedBinding>(R.layout.fragment_
             showPopupMenu = { view, wineyFeed ->
                 showPopupMenu(view, wineyFeed)
             },
-            toFeedDetail = { feedId, writerLevel -> navigateToDetail(feedId, writerLevel) }
+            toFeedDetail = { feedId, writerId -> navigateToDetail(feedId, writerId) }
         )
         binding.rvMyfeedPost.adapter = myFeedAdapter.withLoadStateFooter(wineyFeedLoadAdapter)
     }
@@ -182,10 +182,10 @@ class MyFeedFragment : BindingFragment<FragmentMyfeedBinding>(R.layout.fragment_
         }
     }
 
-    private fun navigateToDetail(feedId: Int, writerLevel: Int) {
+    private fun navigateToDetail(feedId: Int, writerId: Int) {
         val intent = Intent(requireContext(), DetailActivity::class.java)
-        intent.putExtra("feedId", feedId)
-        intent.putExtra("writerLevel", writerLevel)
+        intent.putExtra(KEY_FEED_ID, feedId)
+        intent.putExtra(KEY_FEED_WRITER_ID, writerId)
         startActivity(intent)
     }
 
@@ -198,7 +198,9 @@ class MyFeedFragment : BindingFragment<FragmentMyfeedBinding>(R.layout.fragment_
     }
 
     companion object {
-        private const val LV_KNIGHT = 2
+        private const val KEY_FEED_ID = "feedId"
+        private const val KEY_FEED_WRITER_ID = "feedWriterId"
+
         private const val MSG_MYFEED_ERROR = "ERROR"
         private const val TAG_DELETE_DIALOG = "DELETE_DIALOG"
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,11 @@
     <!-- snackbar -->
     <string name="snackbar_upload_success">업로드가 완료되었습니다 :)</string>
     <string name="snackbar_upload_fail">죄송합니다. 업로드에 실패했습니다 :(</string>
+    <string name="snackbar_feed_delete_success">게시물이 삭제되었습니다</string>
+    <string name="snackbar_comment_delete_success">댓글이 삭제되었습니다 :)</string>
+    <string name="snackbar_delete_fail">죄송합니다. 다시 시도해주세요.</string>
+    <string name="snackbar_report_success">정상적으로 신고되었습니다 :)</string>
+    <string name="snackbar_report_fail">죄송합니다. 신고접수에 실패하였습니다.</string>
 
     <!-- comment -->
     <string name="comment_level_1">LV. 평민 ㆍ </string>


### PR DESCRIPTION
- closed #135 
- closed #136 

## 📝 Work Description

- 상세페이지 좋아요 구현
- 상세페이지 신고, 삭제 팝업메뉴 구현
- 팝업메뉴 각각의 다이얼로그와 그에 따른 삭제 서버통신 구현
- 성공 시 스낵바 구현
- 좋아요, 삭제, 신고 완료 시 위니피드 , 마이피드에 해당 사항 반영

## 📣 To Reviewers
브랜치 머지해서 그냥 한번에 PR 올립니다 최대한 빠르게부탁드려용
- 팝업메뉴 띄우는거 피드랑 댓글별로 함수 분리해뒀습니다
- 메인액비티에 스낵바 띄우는거 함수 통일 시켜뒀습니다 !
둘 다 코드 보면 바로 사용할 수 있을거예요 ~!
