### PR TITLE
[fix] 위니 업로드 / 절약 내용 에디트텍스트가 비어있으면 버튼 활성화 되지 않도록 변경 

### DIFF
--- a/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -250,6 +250,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
 
                 is UiState.Failure -> {
                     snackBar(binding.root) { state.msg }
+                    finish() // 디테일 액티비티 종료
                 }
 
                 else -> Timber.tag("failure").e(MSG_DETAIL_ERROR)

--- a/app/src/main/java/com/android/go/sopt/winey/presentation/nickname/NicknameViewModel.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/presentation/nickname/NicknameViewModel.kt
@@ -4,10 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.go.sopt.winey.data.model.remote.request.RequestPatchNicknameDto
 import com.android.go.sopt.winey.domain.repository.AuthRepository
-import com.android.go.sopt.winey.util.code.NicknameErrorCode.CODE_DUPLICATE
-import com.android.go.sopt.winey.util.code.NicknameErrorCode.CODE_INVALID_LENGTH
-import com.android.go.sopt.winey.util.code.NicknameErrorCode.CODE_SPACE_SPECIAL_CHAR
-import com.android.go.sopt.winey.util.code.NicknameErrorCode.CODE_UNCHECKED_DUPLICATION
+import com.android.go.sopt.winey.util.code.ErrorCode.CODE_DUPLICATE
+import com.android.go.sopt.winey.util.code.ErrorCode.CODE_INVALID_LENGTH
+import com.android.go.sopt.winey.util.code.ErrorCode.CODE_SPACE_SPECIAL_CHAR
+import com.android.go.sopt.winey.util.code.ErrorCode.CODE_UNCHECKED_DUPLICATION
 import com.android.go.sopt.winey.util.view.InputUiState
 import com.android.go.sopt.winey.util.view.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/android/go/sopt/winey/util/binding/BindingAdapter.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/util/binding/BindingAdapter.kt
@@ -11,7 +11,7 @@ import androidx.databinding.BindingAdapter
 import coil.load
 import coil.transform.RoundedCornersTransformation
 import com.android.go.sopt.winey.R
-import com.android.go.sopt.winey.util.code.NicknameErrorCode.*
+import com.android.go.sopt.winey.util.code.ErrorCode.*
 import com.android.go.sopt.winey.util.context.colorOf
 import com.android.go.sopt.winey.util.context.drawableOf
 import com.android.go.sopt.winey.util.context.stringOf
@@ -66,8 +66,32 @@ fun ImageView.setRoundedImage(imageUri: Uri?, drawable: Drawable) {
     }
 }
 
-@BindingAdapter("setBackground")
-fun EditText.setBackground(inputUiState: InputUiState) {
+@BindingAdapter("setUploadContentBackground")
+fun EditText.setUploadContentBackground(inputUiState: InputUiState) {
+    background = if (inputUiState is Empty || inputUiState is Success) {
+        context.drawableOf(R.drawable.sel_nickname_edittext_focus_color)
+    } else {
+        context.drawableOf(R.drawable.shape_red_line_5_rect)
+    }
+}
+
+@BindingAdapter("setUploadContentHelperText")
+fun TextView.setUploadContentHelperText(inputUiState: InputUiState) {
+    if (inputUiState is Empty || inputUiState is Success) {
+        visibility = View.INVISIBLE
+        return
+    }
+
+    if (inputUiState is Failure) {
+        visibility = View.VISIBLE
+        if (inputUiState.code == CODE_INVALID_LENGTH) {
+            text = context.stringOf(R.string.upload_content_error_text)
+        }
+    }
+}
+
+@BindingAdapter("setNicknameBackground")
+fun EditText.setNicknameBackground(inputUiState: InputUiState) {
     background = when (inputUiState) {
         is Empty -> context.drawableOf(R.drawable.sel_nickname_edittext_focus_color)
         is Success -> context.drawableOf(R.drawable.shape_blue_line_5_rect)
@@ -75,8 +99,8 @@ fun EditText.setBackground(inputUiState: InputUiState) {
     }
 }
 
-@BindingAdapter("setHelperText")
-fun TextView.setHelperText(inputUiState: InputUiState) {
+@BindingAdapter("setNicknameHelperText")
+fun TextView.setNicknameHelperText(inputUiState: InputUiState) {
     when (inputUiState) {
         is Empty -> {
             visibility = View.INVISIBLE
@@ -99,8 +123,8 @@ fun TextView.setHelperText(inputUiState: InputUiState) {
     }
 }
 
-@BindingAdapter("setHelperTextColor")
-fun TextView.setHelperTextColor(inputUiState: InputUiState) {
+@BindingAdapter("setNicknameHelperTextColor")
+fun TextView.setNicknameHelperTextColor(inputUiState: InputUiState) {
     when (inputUiState) {
         is Empty -> setTextColor(context.colorOf(R.color.gray_200))
         is Success -> setTextColor(context.colorOf(R.color.blue_500))

--- a/app/src/main/java/com/android/go/sopt/winey/util/code/ErrorCode.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/util/code/ErrorCode.kt
@@ -1,6 +1,6 @@
 package com.android.go.sopt.winey.util.code
 
-enum class NicknameErrorCode {
+enum class ErrorCode {
     CODE_INVALID_LENGTH,
     CODE_SPACE_SPECIAL_CHAR,
     CODE_UNCHECKED_DUPLICATION,

--- a/app/src/main/java/com/android/go/sopt/winey/util/view/InputUiState.kt
+++ b/app/src/main/java/com/android/go/sopt/winey/util/view/InputUiState.kt
@@ -1,9 +1,9 @@
 package com.android.go.sopt.winey.util.view
 
-import com.android.go.sopt.winey.util.code.NicknameErrorCode
+import com.android.go.sopt.winey.util.code.ErrorCode
 
 sealed class InputUiState {
     object Empty : InputUiState()
     object Success : InputUiState()
-    data class Failure(val code: NicknameErrorCode) : InputUiState()
+    data class Failure(val code: ErrorCode) : InputUiState()
 }

--- a/app/src/main/res/layout/activity_nickname.xml
+++ b/app/src/main/res/layout/activity_nickname.xml
@@ -69,7 +69,7 @@
                 <EditText
                     android:id="@+id/et_nickname"
                     style="?editTextStyle"
-                    setBackground="@{vm.inputUiState}"
+                    setNicknameBackground="@{vm.inputUiState}"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:hint="@string/nickname_hint"
@@ -115,8 +115,8 @@
 
         <TextView
             android:id="@+id/tv_nickname_helper_text"
-            setHelperText="@{vm.inputUiState}"
-            setHelperTextColor="@{vm.inputUiState}"
+            setNicknameHelperText="@{vm.inputUiState}"
+            setNicknameHelperTextColor="@{vm.inputUiState}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"

--- a/app/src/main/res/layout/fragment_content.xml
+++ b/app/src/main/res/layout/fragment_content.xml
@@ -86,11 +86,11 @@
         <EditText
             android:id="@+id/et_upload_content"
             style="?editTextStyle"
+            setUploadContentBackground="@{vm.inputUiState}"
             android:layout_width="0dp"
             android:layout_height="90dp"
             android:layout_marginHorizontal="16dp"
             android:layout_marginTop="24dp"
-            android:background="@{vm.isValidContent ? @drawable/sel_upload_edittext_focus_color : @drawable/shape_red_line_10_rect}"
             android:gravity="top"
             android:hint="@string/upload_content_edittext_hint"
             android:importantForAutofill="no"
@@ -105,6 +105,7 @@
             app:layout_constraintTop_toBottomOf="@id/tv_content_detail" />
 
         <TextView
+            setUploadContentHelperText="@{vm.inputUiState}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
@@ -112,7 +113,6 @@
             android:text="@string/upload_content_error_text"
             android:textAppearance="@style/TextAppearance.WINEY.body_m_14"
             android:textColor="?colorError"
-            android:visibility="@{vm.isValidContent ? View.GONE : View.VISIBLE}"
             app:layout_constraintStart_toStartOf="@id/et_upload_content"
             app:layout_constraintTop_toBottomOf="@id/et_upload_content" />
 


### PR DESCRIPTION
## 📝 Work Description

- 절약 금액은 에러 표시가 따로 없어서 Boolean 타입의 StateFlow로 입력 상태를 관찰해도 충분했지만 
- 절약 내용은 6자 이상이 되지 않으면 에러가 표시되고, 내용이 비어있거나 유효한 값일 때는 그냥 에디트텍스트에 포커스만 잡힙니다. (purple 색) 
- 따라서 Boolean 타입 대신에 Empty, Success, Failure 이렇게 3가지로 입력 상태를 관찰하기 위해! 닉네임에 쓰였던 InputUiState 사용했습니다! 

## 📣 To Reviewers

- 코드 변경 사항 확인 부탁드려요! 
