### PR TITLE
[mod] 마이 피드 / 상세페이지에서 삭제시 화면 처리

### DIFF
--- a/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
@@ -47,10 +47,10 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     private fun initFragment() {
         if (intent.getBooleanExtra("navigateMypage", false)) {
-            navigateToMyPageWithBundle("fromNoti","true")
+            navigateToMyPageWithBundle("fromNoti", "true")
         } else {
             if (prevScreenName == MY_FEED_SCREEN) {
-                navigateToMyPageWithBundle("toMyFeed","true")
+                navigateToMyPageWithBundle("toMyFeed", "true")
             } else {
                 navigateTo<WineyFeedFragment>()
             }
@@ -129,7 +129,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         }
     }
 
-    private fun navigateToMyPageWithBundle(key:String, value: String) {
+    private fun navigateToMyPageWithBundle(key: String, value: String) {
         supportFragmentManager.commit {
             val bundle = Bundle()
             bundle.putString(key, value)

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
@@ -46,11 +46,11 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     }
 
     private fun initFragment() {
-        if (intent.getBooleanExtra("navigateMypage", false)) {
-            navigateToMyPageWithBundle("fromNoti", true)
+        if (intent.getBooleanExtra(KEY_TO_MYPAGE, false)) {
+            navigateToMyPageWithBundle(KEY_FROM_NOTI, true)
         } else {
             if (prevScreenName == MY_FEED_SCREEN) {
-                navigateToMyPageWithBundle("toMyFeed", true)
+                navigateToMyPageWithBundle(KEY_TO_MYFEED, true)
             } else {
                 navigateTo<WineyFeedFragment>()
             }
@@ -148,6 +148,9 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         private const val EXTRA_REPORT_KEY = "report"
 
         private const val KEY_PREV_SCREEN = "PREV_SCREEN_NAME"
+        private const val KEY_FROM_NOTI = "fromNoti"
+        private const val KEY_TO_MYFEED = "toMyFeed"
+        private const val KEY_TO_MYPAGE = "navigateMypage"
 
         private const val MY_FEED_SCREEN = "MyFeedFragment"
     }

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
@@ -130,16 +130,19 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     }
 
     private fun navigateToMyPageWithBundle(key: String, value: String) {
-        supportFragmentManager.commit {
-            val bundle = Bundle()
-            bundle.putString(key, value)
-            val myPageFragment = MyPageFragment()
-            myPageFragment.arguments = bundle
-            val transaction = supportFragmentManager.beginTransaction()
-            transaction.replace(R.id.fcv_main, myPageFragment)
-            transaction.commit()
-            binding.bnvMain.selectedItemId = R.id.menu_mypage
+        val bundle = Bundle().apply {
+            putString(key, value)
         }
+        val myPageFragment = MyPageFragment().apply {
+            arguments = bundle
+        }
+        supportFragmentManager.commit {
+            replace(R.id.fcv_main, myPageFragment)
+            setReorderingAllowed(true)
+            addToBackStack(null)
+        }
+        binding.bnvMain.selectedItemId = R.id.menu_mypage
+
     }
 
     companion object {

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
@@ -15,7 +15,6 @@ import org.go.sopt.winey.R
 import org.go.sopt.winey.databinding.ActivityMainBinding
 import org.go.sopt.winey.presentation.main.feed.WineyFeedFragment
 import org.go.sopt.winey.presentation.main.mypage.MyPageFragment
-import org.go.sopt.winey.presentation.main.mypage.myfeed.MyFeedFragment
 import org.go.sopt.winey.presentation.main.recommend.RecommendFragment
 import org.go.sopt.winey.presentation.onboarding.login.LoginActivity
 import org.go.sopt.winey.util.binding.BindingActivity
@@ -48,17 +47,10 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     private fun initFragment() {
         if (intent.getBooleanExtra("navigateMypage", false)) {
-            val bundle = Bundle()
-            bundle.putString("fromNoti", "true")
-            val myPageFragment = MyPageFragment()
-            myPageFragment.arguments = bundle
-            val transaction = supportFragmentManager.beginTransaction()
-            transaction.replace(R.id.fcv_main, myPageFragment)
-            transaction.commit()
-            binding.bnvMain.selectedItemId = R.id.menu_mypage
+            navigateToMyPageWithBundle("fromNoti","true")
         } else {
             if (prevScreenName == MY_FEED_SCREEN) {
-                navigateTo<MyFeedFragment>()
+                navigateToMyPageWithBundle("toMyFeed","true")
             } else {
                 navigateTo<WineyFeedFragment>()
             }
@@ -137,6 +129,19 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         }
     }
 
+    private fun navigateToMyPageWithBundle(key:String, value: String) {
+        supportFragmentManager.commit {
+            val bundle = Bundle()
+            bundle.putString(key, value)
+            val myPageFragment = MyPageFragment()
+            myPageFragment.arguments = bundle
+            val transaction = supportFragmentManager.beginTransaction()
+            transaction.replace(R.id.fcv_main, myPageFragment)
+            transaction.commit()
+            binding.bnvMain.selectedItemId = R.id.menu_mypage
+        }
+    }
+
     companion object {
         private const val EXTRA_UPLOAD_KEY = "upload"
         private const val EXTRA_DELETE_KEY = "delete"
@@ -144,7 +149,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
         private const val KEY_PREV_SCREEN = "PREV_SCREEN_NAME"
 
-        private const val WINEY_FEED_SCREEN = "WineyFeedFragment"
         private const val MY_FEED_SCREEN = "MyFeedFragment"
     }
 }

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
@@ -15,6 +15,7 @@ import org.go.sopt.winey.R
 import org.go.sopt.winey.databinding.ActivityMainBinding
 import org.go.sopt.winey.presentation.main.feed.WineyFeedFragment
 import org.go.sopt.winey.presentation.main.mypage.MyPageFragment
+import org.go.sopt.winey.presentation.main.mypage.myfeed.MyFeedFragment
 import org.go.sopt.winey.presentation.main.recommend.RecommendFragment
 import org.go.sopt.winey.presentation.onboarding.login.LoginActivity
 import org.go.sopt.winey.util.binding.BindingActivity
@@ -29,6 +30,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     private val isUploadSuccess by lazy { intent.extras?.getBoolean(EXTRA_UPLOAD_KEY, false) }
     private val isDeleteSuccess by lazy { intent.extras?.getBoolean(EXTRA_DELETE_KEY, false) }
     private val isReportSuccess by lazy { intent.extras?.getBoolean(EXTRA_REPORT_KEY, false) }
+    private val prevScreenName by lazy { intent.extras?.getString(KEY_PREV_SCREEN, "") }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -55,7 +57,11 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
             transaction.commit()
             binding.bnvMain.selectedItemId = R.id.menu_mypage
         } else {
-            navigateTo<WineyFeedFragment>()
+            if (prevScreenName == MY_FEED_SCREEN) {
+                navigateTo<MyFeedFragment>()
+            } else {
+                navigateTo<WineyFeedFragment>()
+            }
         }
     }
 
@@ -135,5 +141,10 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         private const val EXTRA_UPLOAD_KEY = "upload"
         private const val EXTRA_DELETE_KEY = "delete"
         private const val EXTRA_REPORT_KEY = "report"
+
+        private const val KEY_PREV_SCREEN = "PREV_SCREEN_NAME"
+
+        private const val WINEY_FEED_SCREEN = "WineyFeedFragment"
+        private const val MY_FEED_SCREEN = "MyFeedFragment"
     }
 }

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
@@ -47,10 +47,10 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     private fun initFragment() {
         if (intent.getBooleanExtra("navigateMypage", false)) {
-            navigateToMyPageWithBundle("fromNoti", "true")
+            navigateToMyPageWithBundle("fromNoti", true)
         } else {
             if (prevScreenName == MY_FEED_SCREEN) {
-                navigateToMyPageWithBundle("toMyFeed", "true")
+                navigateToMyPageWithBundle("toMyFeed", true)
             } else {
                 navigateTo<WineyFeedFragment>()
             }
@@ -129,20 +129,17 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         }
     }
 
-    private fun navigateToMyPageWithBundle(key: String, value: String) {
-        val bundle = Bundle().apply {
-            putString(key, value)
-        }
-        val myPageFragment = MyPageFragment().apply {
-            arguments = bundle
-        }
+    private fun navigateToMyPageWithBundle(key: String, value: Boolean) {
         supportFragmentManager.commit {
-            replace(R.id.fcv_main, myPageFragment)
-            setReorderingAllowed(true)
-            addToBackStack(null)
+            val bundle = Bundle()
+            bundle.putBoolean(key, value)
+            val myPageFragment = MyPageFragment()
+            myPageFragment.arguments = bundle
+            val transaction = supportFragmentManager.beginTransaction()
+            transaction.replace(R.id.fcv_main, myPageFragment)
+            transaction.commit()
+            binding.bnvMain.selectedItemId = R.id.menu_mypage
         }
-        binding.bnvMain.selectedItemId = R.id.menu_mypage
-
     }
 
     companion object {

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/MainActivity.kt
@@ -135,9 +135,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
             bundle.putBoolean(key, value)
             val myPageFragment = MyPageFragment()
             myPageFragment.arguments = bundle
-            val transaction = supportFragmentManager.beginTransaction()
-            transaction.replace(R.id.fcv_main, myPageFragment)
-            transaction.commit()
+            replace(R.id.fcv_main, myPageFragment)
             binding.bnvMain.selectedItemId = R.id.menu_mypage
         }
     }

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/feed/WineyFeedFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/feed/WineyFeedFragment.kt
@@ -400,6 +400,7 @@ class WineyFeedFragment :
         val intent = Intent(requireContext(), DetailActivity::class.java)
         intent.putExtra(KEY_FEED_ID, wineyFeed.feedId)
         intent.putExtra(KEY_FEED_WRITER_ID, wineyFeed.userId)
+        intent.putExtra(KEY_PREV_SCREEN, WINEY_FEED_SCREEN)
         startActivity(intent)
     }
 
@@ -442,5 +443,7 @@ class WineyFeedFragment :
 
         private const val KEY_FEED_ID = "feedId"
         private const val KEY_FEED_WRITER_ID = "feedWriterId"
+        private const val KEY_PREV_SCREEN = "PREV_SCREEN_NAME"
+        private const val WINEY_FEED_SCREEN = "WineyFeedFragment"
     }
 }

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -337,7 +337,6 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         }.launchIn(lifecycleScope)
     }
 
-
     private fun initPostCommentStateObserver() {
         viewModel.postCommentState.flowWithLifecycle(lifecycle)
             .onEach { state ->

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -462,9 +462,6 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         private const val TAG_COMMENT_DELETE_DIALOG = "COMMENT_DELETE_DIALOG"
         private const val TAG_REPORT_DIALOG = "REPORT_DIALOG"
 
-        private const val MY_FEED_SCREEN = "MyFeedFragment"
-        private const val WINEY_FEED_SCREEN = "WineyFeedFragment"
-
         private const val POPUP_MENU_POS_OFFSET = 65
         private const val MSG_DETAIL_ERROR = "ERROR"
         private const val EXTRA_DELETE_KEY = "delete"

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -43,6 +43,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
 
     private val feedId by lazy { intent.getIntExtra(KEY_FEED_ID, 0) }
     private val feedWriterId by lazy { intent.getIntExtra(KEY_FEED_WRITER_ID, 0) }
+    private val prevScreenName by lazy { intent.extras?.getString(KEY_PREV_SCREEN, "") }
 
     private var _detailFeedAdapter: DetailFeedAdapter? = null
     private val detailFeedAdapter get() = requireNotNull(_detailFeedAdapter)
@@ -336,6 +337,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         }.launchIn(lifecycleScope)
     }
 
+
     private fun initPostCommentStateObserver() {
         viewModel.postCommentState.flowWithLifecycle(lifecycle)
             .onEach { state ->
@@ -416,6 +418,7 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         Intent(this, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             putExtra(extraKey, true)
+            putExtra(KEY_PREV_SCREEN, prevScreenName)
             startActivity(this)
         }
     }
@@ -454,9 +457,15 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
     companion object {
         private const val KEY_FEED_ID = "feedId"
         private const val KEY_FEED_WRITER_ID = "feedWriterId"
+        private const val KEY_PREV_SCREEN = "PREV_SCREEN_NAME"
+
         private const val TAG_FEED_DELETE_DIALOG = "FEED_DELETE_DIALOG"
         private const val TAG_COMMENT_DELETE_DIALOG = "COMMENT_DELETE_DIALOG"
         private const val TAG_REPORT_DIALOG = "REPORT_DIALOG"
+
+        private const val MY_FEED_SCREEN = "MyFeedFragment"
+        private const val WINEY_FEED_SCREEN = "WineyFeedFragment"
+
         private const val POPUP_MENU_POS_OFFSET = 65
         private const val MSG_DETAIL_ERROR = "ERROR"
         private const val EXTRA_DELETE_KEY = "delete"

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.replace
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import com.google.android.gms.common.config.GservicesValue.value
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
@@ -68,7 +67,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         override fun handleOnBackPressed() {
             val receivedBundle = arguments
             if (receivedBundle != null) {
-                val value = receivedBundle.getBoolean("fromNoti")
+                val value = receivedBundle.getBoolean(KEY_FROM_NOTI)
                 if (value) {
                     val intent = Intent(requireContext(), NotificationActivity::class.java)
                     startActivity(intent)
@@ -102,7 +101,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
     private fun initNavigation() {
         val receivedBundle = arguments
         if (receivedBundle != null) {
-            val value = receivedBundle.getBoolean("toMyFeed")
+            val value = receivedBundle.getBoolean(KEY_TO_MYFEED)
             if (value) {
                 navigateAndBackStack<MyFeedFragment>()
                 arguments = null
@@ -294,5 +293,8 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         private const val EXTRA_VALUE = "MyPageFragment"
         private const val TAG_LOGOUT_DIALOG = "LOGOUT_DIALOG"
         private const val TAGE_WITHDRAW_DIALOG = "WITHDRAW_DIALOG"
+
+        private const val KEY_FROM_NOTI = "fromNoti"
+        private const val KEY_TO_MYFEED = "toMyFeed"
     }
 }

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
@@ -98,7 +98,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         }
     }
 
-    private fun initNavigation(){
+    private fun initNavigation() {
         val receivedBundle = arguments
         if (receivedBundle != null) {
             val value = receivedBundle.getString("toMyFeed")

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.replace
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.google.android.gms.common.config.GservicesValue.value
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
@@ -67,8 +68,8 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         override fun handleOnBackPressed() {
             val receivedBundle = arguments
             if (receivedBundle != null) {
-                val value = receivedBundle.getString("fromNoti")
-                if (value == "true") {
+                val value = receivedBundle.getBoolean("fromNoti")
+                if (value) {
                     val intent = Intent(requireContext(), NotificationActivity::class.java)
                     startActivity(intent)
                     requireActivity().finish()
@@ -101,8 +102,8 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
     private fun initNavigation() {
         val receivedBundle = arguments
         if (receivedBundle != null) {
-            val value = receivedBundle.getString("toMyFeed")
-            if (value == "true") {
+            val value = receivedBundle.getBoolean("toMyFeed")
+            if (value) {
                 navigateAndBackStack<MyFeedFragment>()
                 arguments = null
             }

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
@@ -50,7 +50,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         amplitudeUtils.logEvent("view_mypage")
-
+        initNavigation()
         init1On1ButtonClickListener()
         initTermsButtonClickListener()
         initLevelHelpButtonClickListener()
@@ -98,6 +98,15 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         }
     }
 
+    private fun initNavigation(){
+        val receivedBundle = arguments
+        if (receivedBundle != null) {
+            val value = receivedBundle.getString("toMyFeed")
+            if (value == "true") {
+                navigateAndBackStack<MyFeedFragment>()
+            }
+        }
+    }
     private fun init1On1ButtonClickListener() {
         binding.clMypageTo1on1.setOnClickListener {
             val url = ONE_ON_ONE_URL

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
@@ -104,9 +104,11 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
             val value = receivedBundle.getString("toMyFeed")
             if (value == "true") {
                 navigateAndBackStack<MyFeedFragment>()
+                arguments = null
             }
         }
     }
+
     private fun init1On1ButtonClickListener() {
         binding.clMypageTo1on1.setOnClickListener {
             val url = ONE_ON_ONE_URL

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
@@ -104,7 +104,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
             val value = receivedBundle.getBoolean(KEY_TO_MYFEED)
             if (value) {
                 navigateAndBackStack<MyFeedFragment>()
-                arguments = null
+                arguments?.clear()
             }
         }
     }

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/myfeed/MyFeedFragment.kt
@@ -140,7 +140,11 @@ class MyFeedFragment : BindingFragment<FragmentMyfeedBinding>(R.layout.fragment_
         viewModel.deleteMyFeedState.flowWithLifecycle(viewLifeCycle).onEach { state ->
             when (state) {
                 is UiState.Success -> {
-                    wineySnackbar(binding.root, true, stringOf(R.string.snackbar_feed_delete_success))
+                    wineySnackbar(
+                        binding.root,
+                        true,
+                        stringOf(R.string.snackbar_feed_delete_success)
+                    )
                     viewModel.initDeleteFeedState()
                 }
 
@@ -183,7 +187,8 @@ class MyFeedFragment : BindingFragment<FragmentMyfeedBinding>(R.layout.fragment_
 
                                     is LoadState.NotLoading -> {
                                         binding.rvMyfeedPost.isVisible = myFeedAdapter.itemCount > 0
-                                        binding.clMyfeedEmpty.isVisible = myFeedAdapter.itemCount == 0
+                                        binding.clMyfeedEmpty.isVisible =
+                                            myFeedAdapter.itemCount == 0
                                         restoreScrollPosition()
                                     }
 
@@ -232,6 +237,7 @@ class MyFeedFragment : BindingFragment<FragmentMyfeedBinding>(R.layout.fragment_
         val intent = Intent(requireContext(), DetailActivity::class.java)
         intent.putExtra(KEY_FEED_ID, wineyFeed.feedId)
         intent.putExtra(KEY_FEED_WRITER_ID, wineyFeed.userId)
+        intent.putExtra(KEY_PREV_SCREEN, MY_FEED_SCREEN)
         startActivity(intent)
     }
 
@@ -246,8 +252,12 @@ class MyFeedFragment : BindingFragment<FragmentMyfeedBinding>(R.layout.fragment_
     companion object {
         private const val KEY_FEED_ID = "feedId"
         private const val KEY_FEED_WRITER_ID = "feedWriterId"
+        private const val KEY_PREV_SCREEN = "PREV_SCREEN_NAME"
+
         private const val POPUP_MENU_OFFSET = 65
         private const val MSG_MYFEED_ERROR = "ERROR"
         private const val TAG_FEED_DELETE_DIALOG = "DELETE_DIALOG"
+
+        private const val MY_FEED_SCREEN = "MyFeedFragment"
     }
 }


### PR DESCRIPTION
- closed #184 

## 📝 Work Description

- 상세페이지 이동 시 전 화면이 무엇인지(위니/마이) 알리기
-  전 화면에 따라 삭제 성공 시 화면 이동 및 스낵바 뜨도록 수정 구현


## 📣 To Reviewers
기존 방법이 백스택에 마이페이지를 남기지 않아서
남기고 마이피드에 삭제 스낵바가 뜰수 있도록 변경했습니다 !
