### PR TITLE
[fix] 닉네임 설정 / 유효한 입력값일 때만 중복체크 하도록 변경

### DIFF
--- a/app/src/main/java/org/go/sopt/winey/presentation/main/feed/upload/UploadViewModel.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/feed/upload/UploadViewModel.kt
@@ -46,7 +46,8 @@ class UploadViewModel @Inject constructor(
     /** Content Fragment */
     val _content = MutableStateFlow("")
     val content: String get() = _content.value
-    val inputUiState: StateFlow<InputUiState> = _content.map { updateInputUiState(it) }
+
+    val inputUiState: StateFlow<InputUiState> = _content.map { checkInputUiState(it) }
         .stateIn(
             initialValue = InputUiState.Empty,
             scope = viewModelScope,
@@ -62,7 +63,7 @@ class UploadViewModel @Inject constructor(
 
     private fun validateContent(state: InputUiState) = state == InputUiState.Success
 
-    private fun updateInputUiState(content: String): InputUiState {
+    private fun checkInputUiState(content: String): InputUiState {
         if (content.isBlank()) return InputUiState.Empty
         if (!checkContentLength((content))) {
             return InputUiState.Failure(ErrorCode.CODE_INVALID_LENGTH)

--- a/app/src/main/java/org/go/sopt/winey/util/binding/BindingAdapter.kt
+++ b/app/src/main/java/org/go/sopt/winey/util/binding/BindingAdapter.kt
@@ -13,7 +13,6 @@ import de.hdodenhof.circleimageview.CircleImageView
 import org.go.sopt.winey.R
 import org.go.sopt.winey.presentation.nickname.NicknameActivity.Companion.MY_PAGE_SCREEN
 import org.go.sopt.winey.presentation.nickname.NicknameActivity.Companion.STORY_SCREEN
-import org.go.sopt.winey.util.code.ErrorCode
 import org.go.sopt.winey.util.code.ErrorCode.*
 import org.go.sopt.winey.util.context.colorOf
 import org.go.sopt.winey.util.context.drawableOf
@@ -84,7 +83,7 @@ fun TextView.setUploadContentHelperText(inputUiState: InputUiState) {
 
     if (inputUiState is Failure) {
         visibility = View.VISIBLE
-        if (inputUiState.code == ErrorCode.CODE_INVALID_LENGTH) {
+        if (inputUiState.code == CODE_INVALID_LENGTH) {
             text = context.stringOf(R.string.upload_content_error_text)
         }
     }
@@ -114,10 +113,11 @@ fun TextView.setNicknameHelperText(inputUiState: InputUiState) {
         is Failure -> {
             visibility = View.VISIBLE
             text = when (inputUiState.code) {
+                CODE_BLANK_INPUT -> context.stringOf(R.string.nickname_blank_input_error)
                 CODE_INVALID_LENGTH -> context.stringOf(R.string.nickname_invalid_length_error)
                 CODE_SPACE_SPECIAL_CHAR -> context.stringOf(R.string.nickname_space_special_char_error)
                 CODE_UNCHECKED_DUPLICATION -> context.stringOf(R.string.nickname_unchecked_duplication_error)
-                CODE_DUPLICATE -> context.stringOf(R.string.nickname_duplicate_error)
+                CODE_DUPLICATED -> context.stringOf(R.string.nickname_duplicated_error)
             }
         }
     }

--- a/app/src/main/java/org/go/sopt/winey/util/code/ErrorCode.kt
+++ b/app/src/main/java/org/go/sopt/winey/util/code/ErrorCode.kt
@@ -1,8 +1,9 @@
 package org.go.sopt.winey.util.code
 
 enum class ErrorCode {
-    CODE_INVALID_LENGTH,
+    CODE_BLANK_INPUT,
     CODE_SPACE_SPECIAL_CHAR,
     CODE_UNCHECKED_DUPLICATION,
-    CODE_DUPLICATE
+    CODE_DUPLICATED,
+    CODE_INVALID_LENGTH
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,10 +148,12 @@
     <string name="nickname_duplicate_check">중복확인</string>
     <string name="nickname_update_complete_btn_text">확인</string>
     <string name="nickname_start_btn_text">시작하기</string>
+
+    <string name="nickname_blank_input_error">입력값이 비어있습니다 :(</string>
     <string name="nickname_invalid_length_error">1~8자로 입력해주세요 :(</string>
     <string name="nickname_space_special_char_error">공백과 특수문자는 사용할 수 없습니다 :(</string>
     <string name="nickname_unchecked_duplication_error">닉네임 중복확인을 해주세요 :(</string>
-    <string name="nickname_duplicate_error">중복된 닉네임입니다 :(</string>
+    <string name="nickname_duplicated_error">중복된 닉네임입니다 :(</string>
     <string name="nickname_valid">사용 가능한 닉네임입니다 :)</string>
 
     <!-- login -->


### PR DESCRIPTION
- closed #197 

## 📝 Work Description

- 중복체크 버튼을 누르면, 그 값이 어떤 값이든 서버로부터 중복 확인을 했었습니다. 그래서 값이 비어있거나 공백 또는 특수문자를 포함한 경우에도 중복되는 닉네임이 아니기만 하면, 사용 가능하다고 뜨는 오류가 발생했습니다. 
- 따라서, 중복 체크 버튼을 눌렀을 때 **유효한 입력값인지 한번 더 검증**하고, 유효한 경우에만 중복체크 서버통신을 진행하도록 변경했습니다. 

## 📣 To Reviewers

- 가능하다면 오늘 저녁까지 리뷰 부탁드립니다! 