### PR TITLE
[hotfix] 스플래시 / 안드로이드 12 미만 버전 대응 

### DIFF
--- a/app/release/output-metadata.json
+++ b/app/release/output-metadata.json
@@ -11,7 +11,7 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 8,
+      "versionCode": 9,
       "versionName": "1.0.0",
       "outputFile": "app-release.apk"
     }

--- a/app/release/output-metadata.json
+++ b/app/release/output-metadata.json
@@ -11,7 +11,7 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 7,
+      "versionCode": 8,
       "versionName": "1.0.0",
       "outputFile": "app-release.apk"
     }

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Winey.SplashScreen" parent="Theme.SplashScreen">
+        <item name="android:windowSplashScreenBackground">@color/black</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@android:color/transparent</item>
+        <item name="postSplashScreenTheme">@style/Theme.Winey</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -28,10 +28,7 @@
     </style>
 
     <style name="Theme.Winey.SplashScreen" parent="Theme.SplashScreen">
-        <item name="android:windowSplashScreenBackground" tools:targetApi="s">@color/black</item>
-        <item name="android:windowSplashScreenAnimatedIcon" tools:targetApi="s">
-            @android:color/transparent
-        </item>
+        <item name="android:windowBackground">@color/black</item>
         <item name="postSplashScreenTheme">@style/Theme.Winey</item>
     </style>
 </resources>

--- a/buildSrc/src/main/java/DefaultConfig.kt
+++ b/buildSrc/src/main/java/DefaultConfig.kt
@@ -3,6 +3,6 @@ object DefaultConfig {
     const val compileSdk = 33
     const val minSdk = 28
     const val targetSdk = 33
-    const val versionCode = 7
+    const val versionCode = 8
     const val versionName = "1.0.0"
 }

--- a/buildSrc/src/main/java/DefaultConfig.kt
+++ b/buildSrc/src/main/java/DefaultConfig.kt
@@ -3,6 +3,6 @@ object DefaultConfig {
     const val compileSdk = 33
     const val minSdk = 28
     const val targetSdk = 33
-    const val versionCode = 8
+    const val versionCode = 9
     const val versionName = "1.0.0"
 }


### PR DESCRIPTION
- closed #202 

## 📝 Work Description

- 안드로이드 버전 10 기기 (갤럭시 노트 9) 에서는 기본 아이콘 뜨는 오류 없어진 거 확인했습니다! 
- 해결 방법은 이슈 내용 확인 부탁 드립니다 :) 

## 📣 To Reviewers

- 현진 언니 기기 (안드로이드 버전 11) 에서도 문제 해결되었는지 확인하고 머지하도록 하겠습니다! 
- 변경 사항 확인 부탁 드려요! 
