### PR TITLE
[fix] 릴리즈 모드에 Proguard 적용 시, 카카오 로그인 안 되는 이슈 해결 

### DIFF
--- a/.github/workflows/pr_checker.yml
+++ b/.github/workflows/pr_checker.yml
@@ -45,23 +45,20 @@ jobs:
           AUTH_BASE_URL: ${{ secrets.AUTH_BASE_URL }}
           KAKAO_NATIVE_KEY: ${{ secrets.KAKAO_NATIVE_KEY }}
           AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
         run: |
           echo auth.base.url=\"$AUTH_BASE_URL\" >> ./local.properties
           echo kakao.native.key=\"$KAKAO_NATIVE_KEY\" >> ./local.properties
+          echo amplitude.api.key=\"$AMPLITUDE_API_KEY\" >> ./local.properties
           echo kakaoNativeKey=$KAKAO_NATIVE_KEY >> ./local.properties
-          echo amplitude.api.key=\"AMPLITUDE_API_KEY\" >> ./local.properties
-
-#      - name: Access Firebase Service
-#        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ./app/google-services.json
+          echo keyAlias=$KEY_ALIAS >> ./local.properties
+          echo keyPassword=$KEY_PASSWORD >> ./local.properties
+          echo storePassword=$STORE_PASSWORD >> ./local.properties
 
       - name: Build debug APK
         run: ./gradlew assembleDebug --stacktrace
-
-#      - name: Upload APK
-#        uses: actions/upload-artifact@v1
-#        with:
-#            name: app
-#            path: app/build/outputs/apk/debug
 
       - name: Run ktlint
         run: ./gradlew ktlintCheck

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ captures/
 # Keystore files
 *.jks
 *.keystore
+*.pem
 
 # Google Services (e.g. APIs or Firebase)
 # google-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,8 +42,18 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("release") {
+            keyAlias = gradleLocalProperties(rootDir).getProperty("keyAlias")
+            keyPassword = gradleLocalProperties(rootDir).getProperty("keyPassword")
+            storeFile = file("winey.jks")
+            storePassword = gradleLocalProperties(rootDir).getProperty("storePassword")
+        }
+    }
+
     buildTypes {
-        getByName("release") {
+        release {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(
@@ -63,9 +73,9 @@ android {
     }
 
     buildFeatures {
+        buildConfig = true
         viewBinding = true
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -8,6 +8,7 @@
 ##---------------Begin: Kakao SDK  ----------
 -keep class com.kakao.sdk.**.model.* { <fields>; }
 -keep class * extends com.google.gson.TypeAdapter
+-keep interface com.kakao.sdk.**.*Api
 ##---------------END: Kakao SDK  ----------
 
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -11,7 +11,6 @@
 -keep interface com.kakao.sdk.**.*Api
 ##---------------END: Kakao SDK  ----------
 
-
 ##---------------Begin: Retrofit  ----------
 # Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
 # EnclosingMethod is required to use InnerClasses.
@@ -77,8 +76,6 @@
 
 ##---------------End : OkHttp --------------
 
-
-
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface
 # class:
@@ -93,5 +90,3 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
-
-

--- a/app/src/main/java/org/go/sopt/winey/data/source/KakaoLoginDataSource.kt
+++ b/app/src/main/java/org/go/sopt/winey/data/source/KakaoLoginDataSource.kt
@@ -2,18 +2,52 @@ package org.go.sopt.winey.data.source
 
 import android.content.Context
 import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.user.UserApiClient
 import org.go.sopt.winey.data.service.KakaoLoginService
 import javax.inject.Inject
 
 class KakaoLoginDataSource @Inject constructor(
-    private val kakaoLoginService: KakaoLoginService
-) {
-    fun loginKakao(kakaoLoginCallBack: (OAuthToken?, Throwable?) -> Unit, context: Context) =
-        kakaoLoginService.loginKakao(kakaoLoginCallBack, context)
+    private val client: UserApiClient
+) : KakaoLoginService {
 
-    fun logoutKakao(kakaoLogoutCallBack: (Throwable?) -> Unit) =
-        kakaoLoginService.logoutKakao(kakaoLogoutCallBack)
+    override fun loginKakao(
+        kakaoLoginCallBack: (OAuthToken?, Throwable?) -> Unit,
+        context: Context
+    ) {
+        val kakaoLoginState =
+            if (client.isKakaoTalkLoginAvailable(context)) {
+                KAKAO_TALK_LOGIN
+            } else {
+                KAKAO_ACCOUNT_LOGIN
+            }
 
-    fun deleteKakaoAccount(kakaoLogoutCallBack: (Throwable?) -> Unit) =
-        kakaoLoginService.deleteKakaoAccount(kakaoLogoutCallBack)
+        when (kakaoLoginState) {
+            KAKAO_TALK_LOGIN -> {
+                client.loginWithKakaoTalk(
+                    context,
+                    callback = kakaoLoginCallBack
+                )
+            }
+
+            KAKAO_ACCOUNT_LOGIN -> {
+                client.loginWithKakaoAccount(
+                    context,
+                    callback = kakaoLoginCallBack
+                )
+            }
+        }
+    }
+
+    override fun logoutKakao(kakaoLogoutCallBack: (Throwable?) -> Unit) {
+        client.logout(kakaoLogoutCallBack)
+    }
+
+    override fun deleteKakaoAccount(kakaoLogoutCallBack: (Throwable?) -> Unit) {
+        client.unlink(kakaoLogoutCallBack)
+    }
+
+    companion object {
+        private const val KAKAO_TALK_LOGIN = 0
+        private const val KAKAO_ACCOUNT_LOGIN = 1
+    }
 }

--- a/app/src/main/java/org/go/sopt/winey/di/ServiceModule.kt
+++ b/app/src/main/java/org/go/sopt/winey/di/ServiceModule.kt
@@ -1,15 +1,11 @@
 package org.go.sopt.winey.di
 
-import android.content.Context
-import com.kakao.sdk.auth.model.OAuthToken
-import com.kakao.sdk.user.UserApiClient
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.go.sopt.winey.data.service.AuthService
 import org.go.sopt.winey.data.service.FeedService
-import org.go.sopt.winey.data.service.KakaoLoginService
 import org.go.sopt.winey.data.service.NotificationService
 import org.go.sopt.winey.data.service.RecommendService
 import retrofit2.Retrofit
@@ -40,47 +36,4 @@ object ServiceModule {
     @Singleton
     fun provideNotificationService(retrofit: Retrofit): NotificationService =
         retrofit.create(NotificationService::class.java)
-
-    @Provides
-    fun provideKakaoLoginService(
-        client: UserApiClient
-    ): KakaoLoginService {
-        return object : KakaoLoginService {
-            override fun loginKakao(
-                kakaoLoginCallBack: (OAuthToken?, Throwable?) -> Unit,
-                context: Context
-            ) {
-                val kakaoLoginState =
-                    if (client.isKakaoTalkLoginAvailable(context)) {
-                        KAKAO_TALK_LOGIN
-                    } else {
-                        KAKAO_ACCOUNT_LOGIN
-                    }
-
-                when (kakaoLoginState) {
-                    KAKAO_TALK_LOGIN -> {
-                        client.loginWithKakaoTalk(
-                            context,
-                            callback = kakaoLoginCallBack
-                        )
-                    }
-
-                    KAKAO_ACCOUNT_LOGIN -> {
-                        client.loginWithKakaoAccount(
-                            context,
-                            callback = kakaoLoginCallBack
-                        )
-                    }
-                }
-            }
-
-            override fun logoutKakao(kakaoLogoutCallBack: (Throwable?) -> Unit) {
-                client.logout(kakaoLogoutCallBack)
-            }
-
-            override fun deleteKakaoAccount(kakaoLogoutCallBack: (Throwable?) -> Unit) {
-                client.unlink(kakaoLogoutCallBack)
-            }
-        }
-    }
 }

--- a/app/src/main/java/org/go/sopt/winey/di/ServiceModule.kt
+++ b/app/src/main/java/org/go/sopt/winey/di/ServiceModule.kt
@@ -14,9 +14,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object ServiceModule {
-    private const val KAKAO_TALK_LOGIN = 0
-    private const val KAKAO_ACCOUNT_LOGIN = 1
-
     @Provides
     @Singleton
     fun provideAuthService(retrofit: Retrofit): AuthService =

--- a/app/src/main/java/org/go/sopt/winey/presentation/onboarding/login/LoginActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/onboarding/login/LoginActivity.kt
@@ -26,7 +26,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class LoginActivity :
     BindingActivity<ActivityLoginBinding>(R.layout.activity_login) {
-    val viewModel: LoginViewModel by viewModels()
+    private val viewModel: LoginViewModel by viewModels()
 
     @Inject
     lateinit var amplitudeUtils: AmplitudeUtils


### PR DESCRIPTION
- closed #214 
- closed #218 

## 📝 Work Description

- 키스토어 관련 정보는 local.properties에 작성 (깃헙에 올리면 안 되는 정보이므로) 
- [이 블로그 글](https://ondestroy.tistory.com/entry/%EC%95%B1-%EB%B0%B0%ED%8F%AC%EC%8B%9C-%EC%B9%B4%EC%B9%B4%EC%98%A4-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%ED%95%B4%EC%8B%9C%ED%82%A4-%EB%AC%B8%EC%A0%9C) 참고하여, 카카오 디벨로퍼에 업로드키에 대한 해시값을 따로 등록해줬습니다! 

## 📣 To Reviewers

키스토어 별명이랑 패스워드를 local.properties에 작성할 때 큰 따옴표로 감싸면 안 되는데,,, 그걸 모르고 거의 3시간을 삽질했습니다,,, 오늘따라 빌드 속도가 유독 느려서 더 오래 걸렸네요 😥😥

아무튼 Proguard 적용 시에는 앱 서명 키 뿐만 아니라 업로드 키에 대한 해시값도 
카카오 디벨로퍼에 등록해줘야 한다는 걸 처음 알았어요!!! (Proguard를 적용해본 것도 처음) 

아래는 구글 플레이 콘솔의  `설정 > 앱 서명` 탭에서 확인할 수 있는 내용입니다! 서명이 이렇게나 중요한 거구나... 느낄 수 있었네욤!!! 

>앱 서명 키 인증서
: **Google에서 각 출시 버전에 서명할 때 사용하는 앱 서명 키**에 대한 공개 인증서입니다. 이 인증서를 사용하여 API 제공업체에 키를 등록하세요. 앱 서명 키 자체는 액세스할 수 없으며 Google 서버에 안전하게 보관됩니다.

>업로드 키 인증서
: 비공개 업로드 키의 공개 인증서입니다. **Google에서 개발자 본인이 제공한 업데이트인지 알 수 있도록** 업로드 키를 사용하여 각 버전에 서명하세요. 아래 인증서를 사용하여 API 제공업체에 업로드 키를 등록하세요.
