### PR TITLE
[fix] 상세 피드 / 댓글 입력창 바깥을 터치했을 때만 키보드가 내려가도록

### DIFF
--- a/app/src/main/java/org/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/feed/detail/DetailActivity.kt
@@ -1,10 +1,12 @@
 package org.go.sopt.winey.presentation.main.feed.detail
 
 import android.content.Intent
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
+import android.widget.EditText
 import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -89,9 +91,23 @@ class DetailActivity : BindingActivity<ActivityDetailBinding>(R.layout.activity_
         }
     }
 
-    override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
-        hideKeyboard()
-        binding.etComment.clearFocus()
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        if (event.action == MotionEvent.ACTION_DOWN) {
+            currentFocus?.let { view ->
+                if (view is EditText) {
+                    val focusView = Rect()
+                    view.getGlobalVisibleRect(focusView)
+
+                    val touchedX = event.x.toInt()
+                    val touchedY = event.y.toInt()
+
+                    if (!focusView.contains(touchedX, touchedY)) {
+                        hideKeyboard()
+                        binding.etComment.clearFocus()
+                    }
+                }
+            }
+        }
         return super.dispatchTouchEvent(event)
     }
 


### PR DESCRIPTION
- closed #221 

## 📝 Work Description

액티비티 화면 전체 말고, 에디트 텍스트 바깥 영역을 터치했을 때만 키보드가 내려가고 에디트텍스트 포커스가 해제되도록 변경했습니다! 

## 📣 To Reviewers

드뎌 메인 브랜치에 버전 1.0.1 태그 붙이고 릴리즈 노트 발행하려고 해요! 
ASAP으로 변경사항 확인해주시면 감사하겠습니다! 