### PR TITLE
[mod] 마이페이지 / 숫자, 문자 정렬

### DIFF
--- a/app/src/main/java/org/go/sopt/winey/util/binding/BindingAdapter.kt
+++ b/app/src/main/java/org/go/sopt/winey/util/binding/BindingAdapter.kt
@@ -1,10 +1,6 @@
 package org.go.sopt.winey.util.binding
 
 import android.net.Uri
-import android.text.Spannable
-import android.text.SpannableStringBuilder
-import android.text.style.ForegroundColorSpan
-import android.text.style.TextAppearanceSpan
 import android.view.View
 import android.widget.EditText
 import android.widget.ImageView
@@ -12,7 +8,6 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatButton
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.databinding.BindingAdapter
 import coil.load
@@ -404,16 +399,22 @@ fun TextView.setMyPageItemDescription(iconType: String?) {
     } ?: " "
 }
 
-@BindingAdapter("setMyPageItemSavedAmount", "iconType")
-fun TextView.setMyPageItemSavedAmount(savedAmount: Int, iconType: String) {
+@BindingAdapter("setMyPageItemSavedMoney", "iconType")
+fun TextView.setMyPageItemSavedMoney(savedAmount: Int, iconType: String) {
+    val context = this.context ?: return
     val money: String = when (iconType) {
-        "AMERICANO" -> "5천원  x  "
-        "CHICKEN" -> "3만원  x  "
-        "SNEAKERS" -> "15만원  x  "
-        "AIRPODS" -> "30만원  x  "
+        "AMERICANO" -> context.stringOf(R.string.mypage_americano_money)
+        "CHICKEN" -> context.stringOf(R.string.mypage_chicken_money)
+        "SNEAKERS" -> context.stringOf(R.string.mypage_sneakers_money)
+        "AIRPODS" -> context.stringOf(R.string.mypage_airpods_money)
         else -> ""
     }
 
+    text = money
+}
+
+@BindingAdapter("setMyPageItemSavedAmount", "iconType")
+fun TextView.setMyPageItemSavedAmount(savedAmount: Int, iconType: String) {
     val amount: String = when (iconType) {
         "AMERICANO" -> (savedAmount / 5000).toString()
         "SNEAKERS" -> (savedAmount / 150000).toString()
@@ -422,40 +423,21 @@ fun TextView.setMyPageItemSavedAmount(savedAmount: Int, iconType: String) {
         else -> ""
     }
 
+    text = amount
+}
+
+@BindingAdapter("setMyPageItemSavedMeasurement", "iconType")
+fun TextView.setMyPageItemSavedMeasurement(savedAmount: Int, iconType: String) {
+    val context = this.context ?: return
     val measurement: String = when (iconType) {
-        "AMERICANO" -> " 잔"
-        "SNEAKERS" -> " 켤레"
-        "AIRPODS" -> " 개"
-        "CHICKEN" -> " 마리"
+        "AMERICANO" -> context.stringOf(R.string.mypage_americano_measurement)
+        "SNEAKERS" -> context.stringOf(R.string.mypage_sneakers_measurement)
+        "AIRPODS" -> context.stringOf(R.string.mypage_airpods_measurement)
+        "CHICKEN" -> context.stringOf(R.string.mypage_chicken_measurement)
         else -> ""
     }
 
-    val spannableString = SpannableStringBuilder()
-        .append(money)
-        .append(amount)
-        .append(measurement)
-
-    spannableString.setSpan(
-        TextAppearanceSpan(context, R.style.TextAppearance_WINEY_detail_m_12),
-        0,
-        money.length,
-        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-    )
-
-    spannableString.setSpan(
-        TextAppearanceSpan(context, R.style.TextAppearance_WINEY_Headline_b_24_xxl),
-        money.length,
-        money.length + amount.length,
-        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-    )
-
-    spannableString.setSpan(
-        ForegroundColorSpan(ContextCompat.getColor(context, R.color.gray_500)),
-        money.length + amount.length,
-        money.length + amount.length + measurement.length,
-        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-    )
-    text = spannableString
+    text = measurement
 }
 
 @BindingAdapter("switchFeedTypeBackground")

--- a/app/src/main/res/layout/item_mypage.xml
+++ b/app/src/main/res/layout/item_mypage.xml
@@ -55,15 +55,63 @@
         <TextView
             android:id="@+id/tv_mypage_money"
             iconType="@{item}"
-            setMyPageItemSavedAmount="@{savedAmount}"
+            setMyPageItemSavedMoney="@{savedAmount}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginVertical="13dp"
             android:textAppearance="@style/TextAppearance.WINEY.detail_m_12"
             android:textColor="@color/gray_700"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/tv_mypage_sign"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintTop_toBottomOf="@id/v_mypage_seperator" />
+
+
+        <TextView
+            android:id="@+id/tv_mypage_sign"
+            android:text="×"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="13dp"
+            android:textAppearance="@style/TextAppearance.WINEY.detail_m_12"
+            android:textColor="@color/gray_700"
+            android:layout_marginHorizontal="8dp"
+            app:layout_constraintEnd_toStartOf="@id/tv_mypage_amount"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_mypage_money"
+            app:layout_constraintTop_toBottomOf="@id/v_mypage_seperator" />
+
+
+        <TextView
+            android:id="@+id/tv_mypage_amount"
+            iconType="@{item}"
+            setMyPageItemSavedAmount="@{savedAmount}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="13dp"
+            android:textAppearance="@style/TextAppearance.WINEY.Headline_b_24_xxl"
+            android:textColor="@color/gray_700"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/tv_mypage_measurement"
+            app:layout_constraintStart_toEndOf="@id/tv_mypage_sign"
+            app:layout_constraintTop_toBottomOf="@id/v_mypage_seperator" />
+
+
+        <TextView
+            android:id="@+id/tv_mypage_measurement"
+            iconType="@{item}"
+            setMyPageItemSavedMeasurement="@{savedAmount}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="13dp"
+            android:layout_marginStart="5dp"
+            android:textAppearance="@style/TextAppearance.WINEY.detail_m_12"
+            android:textColor="@color/gray_500"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_mypage_amount"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintTop_toBottomOf="@id/v_mypage_seperator" />
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,6 +157,14 @@
     <string name="mypage_2weeks_save_for_1year">이렇게 절약한다면 일년 후에 %s이 모여요!</string>
     <string name="mypage_2weeks_spend_for_1year">이렇게 낭비한다면 일년 후에 %s이 사라져요!</string>
 
+    <string name="mypage_americano_money">5천원</string>
+    <string name="mypage_sneakers_money">15만원</string>
+    <string name="mypage_airpods_money">30만원</string>
+    <string name="mypage_chicken_money">3만원</string>
+    <string name="mypage_americano_measurement">잔</string>
+    <string name="mypage_sneakers_measurement">켤레</string>
+    <string name="mypage_airpods_measurement">개</string>
+    <string name="mypage_chicken_measurement">마리</string>
 
     <string name="mypage_logout_dialog_title">정말 로그아웃 하시겠어요?</string>
     <string name="mypage_logout_dialog_subtitle">로그아웃 후 장기간 미접속 시\n레벨이 내려갈 수 있습니다.</string>


### PR DESCRIPTION
- closed #277 

## 📝 Work Description

- 마이페이지 절약 아이템 중앙 정렬

## 📣 To Reviewers
- AS-IS
<img width="130" alt="image" src="https://github.com/team-winey/Winey-AOS/assets/81434152/492d12a4-6260-4ab4-9f71-980cc4ed7ac4">

- TO-BE
<img width="130" alt="image" src="https://github.com/team-winey/Winey-AOS/assets/81434152/58dc04bf-a610-4bb4-a233-89d852d1cf32">

아래의 텍스트가 간단한 디자인이지만 각각 폰트 크기, 색상이 달라 spannableStringBuilder로 만들어주었는데, 하나의 textView가 되다 보니 위의 요구사항 처럼 각각의 글자가 따로 정렬이 되지 않았습니다. 따라서 다시 각각 textView로 분리해 디자인 요구사항을 만족하게 두었습니다.