### PR TITLE
[hotfix] 마이페이지 / 로딩 프로그레스바 추가

### DIFF
--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
@@ -269,10 +269,21 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         }
     }
 
+    private fun showLoadingProgressBar() {
+        binding.pbMypageLoading.isVisible = true
+        binding.svMypage.isVisible = false
+    }
+
+    private fun dismissLoadingProgressBar() {
+        binding.pbMypageLoading.isVisible = false
+        binding.svMypage.isVisible = true
+    }
+
     private fun setupGetUserStateObserver() {
         mainViewModel.getUserState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
                 is UiState.Success -> {
+                    dismissLoadingProgressBar()
                     val data = dataStoreRepository.getUserInfo().first() ?: return@onEach
                     updateUserInfo(data)
                     setUpUserGoalByLevel(data)
@@ -283,6 +294,10 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
 
                 is UiState.Failure -> {
                     snackBar(binding.root) { state.msg }
+                }
+
+                is UiState.Loading -> {
+                    showLoadingProgressBar()
                 }
 
                 else -> {}

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
@@ -22,6 +22,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
@@ -280,11 +281,12 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
     }
 
     private fun setupGetUserStateObserver() {
-        mainViewModel.getUserState.flowWithLifecycle(lifecycle).onEach { state ->
+        mainViewModel.getUserState.flowWithLifecycle(lifecycle).onEach launch@{ state ->
             when (state) {
                 is UiState.Success -> {
                     dismissLoadingProgressBar()
-                    val data = dataStoreRepository.getUserInfo().first() ?: return@onEach
+                    delay(100)
+                    val data = dataStoreRepository.getUserInfo().first() ?: return@launch
                     updateUserInfo(data)
                     setUpUserGoalByLevel(data)
                     setUpUserDataByGoal(data)

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -14,6 +14,16 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <ProgressBar
+            android:id="@+id/pb_mypage_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+
         <TextView
             android:id="@+id/tv_mypage_title"
             android:layout_width="wrap_content"


### PR DESCRIPTION
- closed #289 

## 📝 Work Description

- 마이페이지 로딩 프로그레스바 추가

## 📣 To Reviewers
로딩 프로그레스바 추가는 간단했는데 추가하고 나니 애니메이션이 제대로 동작하지 않았습니다. 추측하는 이유는 프로그레스 바 상태를 변경(보여주고, 숨기고)는 당연히 UI 스레드에서 처리되는데 코드의 실행으로 인한 변경은 즉각적이지만, 실제로 UI가 갱신되어 사용자에게 보여지기까지는 아주 약간의 시간이 필요해서인것 같아요. 그 과정에서 애니메이션을 보여주는 코드와 경쟁이 일어나지 않았나 싶습니다.

일단은 0.1초의 딜레이를 주어서 해결했습니다 ! 다른 해결방법 후보군으로는
- 로딩 프로그레스바의 가시성을 stateflow로 관찰해서 해당 상태가 show이면 애니메이션 시작하게
- async, await 로 순서 보장

이렇게 두가지를 생각해봤는데 아무래도 딜레이 한줄이 제일 코드가 간단하긴 해서 해당 방식으로 해결해보았습니다 ! 그치만 0.1초이긴 해도 강제적으로 딜레이를 주는게 좋은 방법은 아닌 듯 하여 혹시 다른 해결 방법 떠오르면 의견 편하게 부탁드려용 😽
