### PR TITLE
[refactor] 마이페이지 / 로딩프로그레스바 - 애니메이션 간의 실행순서 보장 로직 개선

### DIFF
--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
@@ -284,13 +284,12 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
                 is UiState.Success -> {
                     dismissLoadingProgressBar()
                     binding.root.post {
-                        state.data?.let {
-                            updateUserInfo(it)
-                            setUpUserGoalByLevel(it)
-                            setUpUserDataByGoal(it)
-                            animate2weeksSaveGraph(it.amountSavedTwoWeeks)
-                            animate2weeksSpendGraph(it.amountSpentTwoWeeks)
-                        }
+                        val data = state.data ?: return@post
+                        updateUserInfo(data)
+                        setUpUserGoalByLevel(data)
+                        setUpUserDataByGoal(data)
+                        animate2weeksSaveGraph(data.amountSavedTwoWeeks)
+                        animate2weeksSpendGraph(data.amountSpentTwoWeeks)
                     }
                 }
 

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/mypage/MyPageFragment.kt
@@ -22,8 +22,6 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -285,13 +283,15 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
             when (state) {
                 is UiState.Success -> {
                     dismissLoadingProgressBar()
-                    delay(100)
-                    val data = dataStoreRepository.getUserInfo().first() ?: return@launch
-                    updateUserInfo(data)
-                    setUpUserGoalByLevel(data)
-                    setUpUserDataByGoal(data)
-                    animate2weeksSaveGraph(data.amountSavedTwoWeeks)
-                    animate2weeksSpendGraph(data.amountSpentTwoWeeks)
+                    binding.root.post {
+                        state.data?.let {
+                            updateUserInfo(it)
+                            setUpUserGoalByLevel(it)
+                            setUpUserDataByGoal(it)
+                            animate2weeksSaveGraph(it.amountSavedTwoWeeks)
+                            animate2weeksSpendGraph(it.amountSpentTwoWeeks)
+                        }
+                    }
                 }
 
                 is UiState.Failure -> {


### PR DESCRIPTION
- closed #290 

## 📝 Work Description

문제 상황은 [저번 PR](https://github.com/team-winey/Winey-AOS/pull/290)을 참고해주세요 !

저때 delay를 통해 100ms동안 강제로 기다리게해 `로딩프로그레스바 비가시화 -> 데이터 불러와 애니메이션 시작` 이라는 순서를 보장하게 해줬는데, delay는 UI스레드 자체를 블로킹하므로 성능을 저하시킨다는 단점이 여전히 존재한다고 느껴서 다른 방법으로 문제를 해결해 개선했습니다.

## ✅  개선 사항
view 클래스의 post함수를 통해서 블로킹없이 실행 순서를 보장시켜주었습니다. 

> Causes the Runnable to be added to the message queue. The runnable will be run on the user interface thread.

`view.post(runnable)`은 핸들러에 연결된 메시지큐에 runnable객체를 넣어서 전달해주는 방식이기때문에 실행코드들이 메시지 큐에 추가되고, 선입선출됩니다. 따라서 현재 수행 중인 다른 UI 업데이트(여기서는 progress bar의 invisible로의 변경)가 완료되고 User 데이터를 활용한 UI업데이트 로직(애니메이션)이 실행되는 **순서가 보장**되기 때문에 기존의 문제가 해결되고, delay를 사용하지 않음으로 **블로킹 또한 없도록 개선**해주었어요 ! 

