### PR TITLE
[refactor] 위니 피드 / 일회성 이벤트는 shared flow 사용하도록 변경 

### DIFF
--- a/app/src/main/java/org/go/sopt/winey/presentation/main/feed/WineyFeedFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/feed/WineyFeedFragment.kt
@@ -14,6 +14,7 @@ import androidx.paging.PagingData
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.SimpleItemAnimator
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -40,6 +41,7 @@ import org.go.sopt.winey.util.amplitude.type.EventType
 import org.go.sopt.winey.util.amplitude.type.EventType.TYPE_CLICK_FEED_ITEM
 import org.go.sopt.winey.util.amplitude.type.EventType.TYPE_CLICK_LIKE
 import org.go.sopt.winey.util.binding.BindingFragment
+import org.go.sopt.winey.util.event.Event
 import org.go.sopt.winey.util.fragment.WineyDialogFragment
 import org.go.sopt.winey.util.fragment.WineyUploadDialogFragment
 import org.go.sopt.winey.util.fragment.snackBar
@@ -107,6 +109,7 @@ class WineyFeedFragment :
         initPostLikeStateObserver()
         initDeleteFeedStateObserver()
         initLevelUpStateObserver()
+        collectEvent()
     }
 
     /** Adapter */
@@ -327,10 +330,6 @@ class WineyFeedFragment :
                     is UiState.Success -> {
                         val pagingData = state.data
                         wineyFeedAdapter.submitData(pagingData)
-
-                        // 상세피드 들어갔다 나올 때, 성공 상태가 계속 관찰되어
-                        // 이미 삭제된 항목이 되살아나는 일이 없도록 UiState 초기화
-                        viewModel.initGetWineyFeedState()
                     }
 
                     is UiState.Failure -> {
@@ -391,17 +390,8 @@ class WineyFeedFragment :
                         val response = state.data ?: return@onEach
                         deletePagingDataItem(response.feedId.toInt())
 
-                        wineySnackbar(
-                            anchorView = binding.root,
-                            message = stringOf(R.string.snackbar_feed_delete_success),
-                            type = SnackbarType.WineyFeedResult(isSuccess = true)
-                        )
-
+                        // 목표 프로그레스바 갱신을 위해 유저 데이터 재조회
                         mainViewModel.getUser()
-
-                        // 상세피드 들어갔다 나올 때 성공 상태가 계속 관찰되어
-                        // 스낵바가 반복해서 뜨지 않도록 UiState 초기화
-                        viewModel.initDeleteFeedState()
                     }
 
                     is UiState.Failure -> {
@@ -411,6 +401,28 @@ class WineyFeedFragment :
                     else -> {}
                 }
             }.launchIn(viewLifeCycleScope)
+    }
+
+    private fun collectEvent() {
+        viewModel.eventFlow.flowWithLifecycle(viewLifeCycle)
+            .onEach { event ->
+                when (event) {
+                    is Event.ShowSnackBar -> {
+                        showFeedDeleteSuccessSnackBar()
+                    }
+
+                    else -> {}
+                }
+            }
+            .launchIn(viewLifeCycleScope)
+    }
+
+    private fun showFeedDeleteSuccessSnackBar() {
+        wineySnackbar(
+            anchorView = binding.root,
+            message = stringOf(R.string.snackbar_feed_delete_success),
+            type = SnackbarType.WineyFeedResult(isSuccess = true)
+        )
     }
 
     private fun deletePagingDataItem(feedId: Int) {

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/feed/WineyFeedFragment.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/feed/WineyFeedFragment.kt
@@ -14,7 +14,6 @@ import androidx.paging.PagingData
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.SimpleItemAnimator
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -41,7 +40,7 @@ import org.go.sopt.winey.util.amplitude.type.EventType
 import org.go.sopt.winey.util.amplitude.type.EventType.TYPE_CLICK_FEED_ITEM
 import org.go.sopt.winey.util.amplitude.type.EventType.TYPE_CLICK_LIKE
 import org.go.sopt.winey.util.binding.BindingFragment
-import org.go.sopt.winey.util.event.Event
+import org.go.sopt.winey.util.event.EventBus
 import org.go.sopt.winey.util.fragment.WineyDialogFragment
 import org.go.sopt.winey.util.fragment.WineyUploadDialogFragment
 import org.go.sopt.winey.util.fragment.snackBar
@@ -407,7 +406,7 @@ class WineyFeedFragment :
         viewModel.eventFlow.flowWithLifecycle(viewLifeCycle)
             .onEach { event ->
                 when (event) {
-                    is Event.ShowSnackBar -> {
+                    is EventBus.ShowSnackBar -> {
                         showFeedDeleteSuccessSnackBar()
                     }
 

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/feed/WineyFeedViewModel.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/feed/WineyFeedViewModel.kt
@@ -14,15 +14,13 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import org.go.sopt.winey.R
 import org.go.sopt.winey.data.model.remote.request.RequestPostLikeDto
 import org.go.sopt.winey.data.model.remote.response.ResponseDeleteFeedDto
 import org.go.sopt.winey.domain.entity.DetailFeed
 import org.go.sopt.winey.domain.entity.Like
 import org.go.sopt.winey.domain.entity.WineyFeed
 import org.go.sopt.winey.domain.repository.FeedRepository
-import org.go.sopt.winey.util.event.Event
-import org.go.sopt.winey.util.fragment.stringOf
+import org.go.sopt.winey.util.event.EventBus
 import org.go.sopt.winey.util.view.UiState
 import retrofit2.HttpException
 import timber.log.Timber
@@ -50,8 +48,8 @@ class WineyFeedViewModel @Inject constructor(
     val deleteWineyFeedState: StateFlow<UiState<ResponseDeleteFeedDto?>> =
         _deleteWineyFeedState.asStateFlow()
 
-    private val _eventFlow = MutableSharedFlow<Event>()
-    val eventFlow: SharedFlow<Event> = _eventFlow.asSharedFlow()
+    private val _eventFlow = MutableSharedFlow<EventBus>()
+    val eventFlow: SharedFlow<EventBus> = _eventFlow.asSharedFlow()
 
     init {
         getWineyFeedList()
@@ -107,13 +105,13 @@ class WineyFeedViewModel @Inject constructor(
             feedRepository.deleteFeed(feedId)
                 .onSuccess { response ->
                     _deleteWineyFeedState.emit(UiState.Success(response))
-                    sendEvent(Event.ShowSnackBar)
+                    sendEvent(EventBus.ShowSnackBar)
                 }
                 .onFailure { t -> handleFailureState(_deleteWineyFeedState, t) }
         }
     }
 
-    private fun sendEvent(event: Event) {
+    private fun sendEvent(event: EventBus) {
         viewModelScope.launch {
             _eventFlow.emit(event)
         }

--- a/app/src/main/java/org/go/sopt/winey/presentation/main/feed/WineyFeedViewModel.kt
+++ b/app/src/main/java/org/go/sopt/winey/presentation/main/feed/WineyFeedViewModel.kt
@@ -133,6 +133,5 @@ class WineyFeedViewModel @Inject constructor(
         private const val CODE_WINEYFEED_INVALID_USER = 404
         private const val CODE_WINEYFEED_INVALID_REQUEST = 400
         private const val MSG_WINEYFEED_FAIL = "FAIL"
-        private const val ERROR_GET_WINEY_FEED_LIST = "error get winey feed list"
     }
 }

--- a/app/src/main/java/org/go/sopt/winey/util/event/Event.kt
+++ b/app/src/main/java/org/go/sopt/winey/util/event/Event.kt
@@ -1,6 +1,0 @@
-package org.go.sopt.winey.util.event
-
-sealed interface Event {
-    object Empty : Event
-    object ShowSnackBar: Event
-}

--- a/app/src/main/java/org/go/sopt/winey/util/event/Event.kt
+++ b/app/src/main/java/org/go/sopt/winey/util/event/Event.kt
@@ -1,0 +1,6 @@
+package org.go.sopt.winey.util.event
+
+sealed interface Event {
+    object Empty : Event
+    object ShowSnackBar: Event
+}

--- a/app/src/main/java/org/go/sopt/winey/util/event/EventBus.kt
+++ b/app/src/main/java/org/go/sopt/winey/util/event/EventBus.kt
@@ -1,0 +1,6 @@
+package org.go.sopt.winey.util.event
+
+sealed interface EventBus {
+    object Empty : EventBus
+    object ShowSnackBar: EventBus
+}


### PR DESCRIPTION
- closed #299

## 📝 Work Description

- 기존에는 위니피드 삭제 성공 이벤트를 StateFlow로 수신하고 있어서, 상세피드 들어갔다가 나올 때마다 매번 스낵바가 반복적으로 뜨는 문제가 있었습니다. (이유: StateFlow가 피드 삭제 UiState의 최신 값을 구독하고 있어서) 
- 가장 최신 데이터를 구독하여 UI 상태를 갱신할 때는 StateFlow, 일회성 이벤트를 처리할 때는 SharedFlow를 사용해야 한다는 걸 뒤늦게 알게 되어서 위니피드 삭제 성공 이벤트는 SharedFlow를 사용하도록 변경했습니다. 

## 📣 To Reviewers
<!-- 원하는 리뷰 요청 기한도 작성해주세요. -->
- 이번주 내로 리뷰 부탁드립니다! 